### PR TITLE
Add 2026 Q2 activity and disclosure report (KO/EN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Korean
 - 2020년 2월 5일 [모스랜드, 더 헌터스 'iF 디자인 어워드 수상](http://s3.ap-northeast-2.amazonaws.com/dunamuplatform-druid-disclosure-coolprod/disclosure-160_MOC_01.pdf)
 
 ## Materials
+- 2026 [MOSSLAND: Progress Report for the Second Quarter of 2026 and Announcements](https://mossland.github.io/Disclosure-and-Materials/disclosures/2026-q2/)
 - 2026 [MOSSLAND: Progress Report for the First Quarter of 2026 and Announcements](https://mossland.github.io/Disclosure-and-Materials/disclosures/2026-q1/)
 - 2026 [MOSSLAND: Progress Report for the Fourth Quarter of 2025 and Announcements](https://mossland.github.io/Disclosure-and-Materials/disclosures/2025-q4/)
 - 2026 [MOSSLAND Research Report: Physical AI & Agentic Expansion (Research Preview)](2026-01-research/physical-ai-agentic-expansion-research.md)

--- a/disclosures/2026-q2/index.html
+++ b/disclosures/2026-q2/index.html
@@ -1,0 +1,1885 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mossland — 2026년 2분기 리포트 · 2026 Q2 Report (v1.0)</title>
+<style>
+  :root{
+    --bg:#fbfaf7; --panel:#ffffff; --ink:#111418; --ink-2:#2e3238;
+    --muted:#5b6068; --line:#e4e2dc; --line-2:#cecac1;
+    --accent:#15665c; --accent-2:#0d4a43; --accent-soft:#e5efec;
+    --warn:#8a6500; --warn-soft:#fbf2d9;
+    --danger:#8a1e1e; --danger-soft:#f7e2e2;
+    --chart-1:#15665c; --chart-2:#c68f2a; --chart-3:#6a7a8d; --chart-4:#8a5e3c; --chart-5:#4a5b52;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Helvetica Neue","Segoe UI","Pretendard","Noto Sans KR",sans-serif;
+    --serif:"Iowan Old Style","Sitka Text","Source Serif Pro",Georgia,"Nanum Myeongjo",serif;
+    /* MossDT §6.6 — original UI plates */
+
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0}
+  body{background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:15px;line-height:1.72;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:48px 28px 120px}
+  header.cover{border-bottom:1px solid var(--line);padding-bottom:40px;margin-bottom:40px}
+  .kicker{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted)}
+  h1.title{font-family:var(--serif);font-weight:500;font-size:46px;line-height:1.12;margin:14px 0 6px;letter-spacing:-.01em}
+  .subtitle{font-family:var(--serif);color:var(--muted);font-size:20px;font-style:italic;margin-bottom:22px}
+  .meta{display:grid;grid-template-columns:repeat(4,1fr);gap:12px 24px;margin-top:12px;font-size:13px}
+  .meta dt{font-family:var(--mono);font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-bottom:4px}
+  .meta dd{margin:0;color:var(--ink-2)}
+  .lang-toggle{display:inline-flex;border:1px solid var(--line-2);border-radius:2px;overflow:hidden;font-family:var(--mono);font-size:11px;letter-spacing:.08em;margin-bottom:22px}
+  .lang-toggle button{background:transparent;color:var(--muted);border:0;padding:6px 14px;cursor:pointer;font:inherit}
+  .lang-toggle button.active{background:var(--ink);color:#fff}
+  h2.section{font-family:var(--serif);font-weight:500;font-size:26px;margin:56px 0 18px;padding-top:24px;border-top:1px solid var(--line);letter-spacing:-.005em}
+  h2.section .num{font-family:var(--mono);font-size:13px;letter-spacing:.1em;color:var(--muted);display:inline-block;min-width:54px}
+  h3{font-family:var(--serif);font-weight:500;font-size:19px;margin:28px 0 10px}
+  h4{font-family:var(--sans);font-weight:600;font-size:14px;margin:20px 0 8px;color:var(--ink-2);letter-spacing:.01em}
+  h5{font-family:var(--mono);font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin:18px 0 8px;font-weight:500}
+  p{margin:0 0 12px}
+  .lead{font-family:var(--serif);font-size:17px;color:var(--ink-2);line-height:1.65}
+  a{color:var(--accent);text-decoration:none;border-bottom:1px solid transparent;transition:border-color .15s}
+  a:hover{border-bottom-color:var(--accent)}
+  code{font-family:var(--mono);font-size:.9em;background:#f2efe9;padding:1px 5px;border-radius:2px;color:var(--ink-2);word-break:break-all}
+  ul,ol{margin:0 0 14px 0;padding-left:22px}
+  ul li,ol li{margin-bottom:6px}
+  .small{font-size:12.5px;color:var(--muted)}
+  .mono{font-family:var(--mono)}
+  hr{border:0;border-top:1px solid var(--line);margin:32px 0}
+  .lang-en{color:var(--muted);font-size:14px;display:block;margin-top:2px;line-height:1.55}
+  p.lang-en{margin-top:-6px;margin-bottom:14px}
+  table{width:100%;border-collapse:collapse;margin:14px 0 18px;font-size:14.5px}
+  th,td{text-align:left;padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:500;border-bottom:1px solid var(--line-2)}
+  td.num{font-family:var(--mono);text-align:right}
+  .kpi{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin:14px 0 18px}
+  .kpi .cell{border:1px solid var(--line);background:var(--panel);padding:14px}
+  .kpi .label{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-bottom:6px}
+  .kpi .value{font-family:var(--serif);font-size:22px;line-height:1.15;color:var(--ink);font-weight:500}
+  .kpi .unit{font-size:12.5px;color:var(--muted);margin-top:4px}
+  .kpi.three{grid-template-columns:repeat(3,1fr)}
+  .kpi.two{grid-template-columns:repeat(2,1fr)}
+  .kpi.six{grid-template-columns:repeat(6,1fr)}
+  @media(max-width:760px){
+    .kpi,.kpi.three,.kpi.six{grid-template-columns:repeat(2,1fr)}
+    .meta{grid-template-columns:repeat(2,1fr)}
+    h1.title{font-size:32px}
+    .wrap{padding:28px 18px 80px}
+  }
+  .callout{border-left:3px solid var(--accent);background:var(--accent-soft);padding:14px 18px;margin:14px 0 18px;font-size:13.5px}
+  .callout.warn{border-left-color:var(--warn);background:var(--warn-soft)}
+  .callout.danger{border-left-color:var(--danger);background:var(--danger-soft)}
+  .callout-title{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-bottom:6px}
+  .toc{column-count:2;column-gap:24px;font-size:13.5px;border:1px solid var(--line);background:var(--panel);padding:18px 22px;margin:14px 0 18px}
+  .toc a{display:block;padding:3px 0;color:var(--ink-2);border:0;break-inside:avoid;-webkit-column-break-inside:avoid;page-break-inside:avoid}
+  .toc a:hover{color:var(--accent)}
+  .toc .num{font-family:var(--mono);color:var(--muted);display:inline-block;min-width:40px}
+  @media(max-width:700px){.toc{column-count:1}}
+  .snap{border:1px solid var(--line);background:var(--panel);padding:20px 22px;margin:0 0 28px}
+  .snap h4{margin-top:0}
+  footer{margin-top:60px;padding-top:24px;border-top:1px solid var(--line);font-size:12px;color:var(--muted);line-height:1.6}
+  .src{font-family:var(--mono);font-size:11px;color:var(--muted)}
+  .src::before{content:"↗ ";color:var(--muted)}
+  .badge{display:inline-block;font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;padding:2px 8px;border:1px solid var(--line-2);color:var(--muted);border-radius:2px;margin-right:6px;vertical-align:middle}
+  .badge.exp{border-color:#c9a45f;color:#7a5610;background:#f6eed2}
+  .badge.ok{border-color:#6a8a6a;color:#2f5a2f;background:#e5f0e5}
+  body.only-ko .lang-en{display:none}
+  body.only-en .lang-ko{display:none}
+  body.only-en .lang-en{display:block;color:var(--ink);font-size:15px;margin-top:0}
+  body.only-en p.lang-en{margin-top:0;margin-bottom:12px}
+  body.only-ko p.lang-en{margin-bottom:0}
+
+
+  /* ---- MossDT actual-screenshot plates ---- */
+  figure.plate{margin:18px 0 22px;padding:0;border:1px solid var(--line);background:#0d1117;position:relative;overflow:hidden}
+  figure.plate .img{aspect-ratio:1.87/1;background-size:cover;background-position:center;background-repeat:no-repeat;filter:saturate(0.94);display:block}
+  figure.plate .img.pl-urban{background-image:var(--plate-urban)}
+  figure.plate .img.pl-inspect{background-image:var(--plate-inspect)}
+  figure.plate .img.pl-sim{background-image:var(--plate-sim)}
+  figure.plate figcaption{padding:8px 14px;background:var(--panel);color:var(--muted);font-family:var(--mono);font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;border-top:1px solid var(--line)}
+
+  /* ---- Figures / SVG containers ---- */
+  figure.viz{margin:18px 0 22px;padding:18px 18px 14px;border:1px solid var(--line);background:var(--panel)}
+
+  figure.viz figcaption{font-family:var(--mono);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-top:10px}
+  figure.viz svg{display:block;width:100%;height:auto}
+  .fig-label{font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+
+  /* ---- CSS bar chart ---- */
+  .bars{margin:10px 0 14px}
+  .bars .row{display:grid;grid-template-columns:140px 1fr 60px;gap:10px;align-items:center;margin-bottom:6px;font-size:13px}
+  .bars .row .label{color:var(--ink-2)}
+  .bars .row .bar{background:#ece9e0;height:12px;position:relative;border:1px solid var(--line)}
+  .bars .row .bar span{position:absolute;left:0;top:0;bottom:0;background:var(--accent)}
+  .bars .row .v{font-family:var(--mono);font-size:12px;color:var(--muted);text-align:right}
+  .bars .row .bar span.c2{background:var(--chart-2)}
+  .bars .row .bar span.c3{background:var(--chart-3)}
+  .bars .row .bar span.c4{background:var(--chart-4)}
+  .bars .row .bar span.c5{background:var(--chart-5)}
+
+  /* ---- Repo grid ---- */
+  .repos{display:grid;grid-template-columns:repeat(7,1fr);gap:4px;margin:12px 0 18px}
+  .repos .tile{border:1px solid var(--line);background:#fff;padding:6px 6px 4px;font-size:10px;line-height:1.3}
+  .repos .tile .n{font-family:var(--mono);font-size:9.5px;color:var(--ink-2);word-break:break-all}
+  .repos .tile .m{color:var(--muted);font-size:9px;margin-top:2px}
+  .repos .tile.hot{background:var(--accent-soft);border-color:var(--accent)}
+  .repos .tile.warm{background:#f7efd9}
+  @media(max-width:760px){.repos{grid-template-columns:repeat(4,1fr)}}
+
+  /* ---- Exchange card ---- */
+  .exlist{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin:12px 0 18px}
+  .exlist .ex{border:1px solid var(--line);background:var(--panel);padding:12px 14px}
+  .exlist .ex .n{font-family:var(--serif);font-size:17px;font-weight:500;color:var(--ink)}
+  .exlist .ex .m{font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);margin-top:4px}
+  @media(max-width:760px){.exlist{grid-template-columns:repeat(2,1fr)}}
+
+  /* ---- Agent cluster grid ---- */
+  .clusters{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin:10px 0 14px}
+  .clusters .cl{border:1px solid var(--line);background:#fff;padding:8px 10px}
+  .clusters .cl .h{font-family:var(--mono);font-size:10px;letter-spacing:.06em;text-transform:uppercase;color:var(--accent)}
+  .clusters .cl .c{font-family:var(--serif);font-size:16px;color:var(--ink)}
+  .clusters .cl .m{font-size:11px;color:var(--muted);margin-top:2px}
+  @media(max-width:760px){.clusters{grid-template-columns:repeat(2,1fr)}}
+
+  /* ---- Utility card ---- */
+  .util{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin:12px 0 18px}
+  .util .u{border:1px solid var(--line);background:#fff;padding:12px}
+  .util .u .t{font-family:var(--serif);font-size:16px;color:var(--ink)}
+  .util .u .d{font-size:12px;color:var(--muted);margin-top:4px;line-height:1.5}
+  @media(max-width:760px){.util{grid-template-columns:repeat(2,1fr)}}
+
+  /* ---- Post card ---- */
+  .posts{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;margin:12px 0 18px}
+  .posts .p{border:1px solid var(--line);background:#fff;padding:14px}
+  .posts .p .d{font-family:var(--mono);font-size:10.5px;color:var(--muted)}
+  .posts .p .t{font-family:var(--serif);font-size:16px;line-height:1.35;margin-top:4px}
+  .posts .p .s{font-size:12.5px;color:var(--ink-2);margin-top:8px;line-height:1.5}
+  @media(max-width:760px){.posts{grid-template-columns:1fr}}
+
+  /* ---- Dashboard mock ---- */
+  .mock{border:1px solid var(--line-2);background:#0d1117;color:#e6edf3;font-family:var(--mono);font-size:11px;padding:16px 18px;margin:12px 0 18px;line-height:1.55}
+  .mock .title-bar{display:flex;align-items:center;gap:6px;margin:-6px -10px 10px;padding-bottom:8px;border-bottom:1px solid #30363d}
+  .mock .dot{width:9px;height:9px;border-radius:50%;background:#8b949e}
+  .mock .dot.r{background:#ff5f57}.mock .dot.y{background:#febc2e}.mock .dot.g{background:#28c840}
+  .mock .fn{color:#8b949e;margin-left:8px}
+  .mock .prompt{color:#7ee787}
+  .mock .ok{color:#7ee787}
+  .mock .hi{color:#ffa657}
+  .mock .muted{color:#8b949e}
+  .mock .stat{display:grid;grid-template-columns:repeat(3,1fr);gap:14px;margin:6px 0 10px}
+  .mock .stat .s .k{color:#8b949e;font-size:9.5px;letter-spacing:.12em;text-transform:uppercase}
+  .mock .stat .s .v{color:#7ee787;font-size:16px;margin-top:2px}
+
+  /* ---- Signal adapter chips ---- */
+  .chips{display:flex;flex-wrap:wrap;gap:6px;margin:10px 0 16px}
+  .chips .c{font-family:var(--mono);font-size:11px;border:1px solid var(--line-2);padding:3px 9px;color:var(--ink-2);background:#fff}
+  .chips .c.accent{background:var(--accent-soft);border-color:var(--accent);color:var(--accent-2)}
+
+  /* ---- Risk matrix ---- */
+  .riskmx{display:grid;grid-template-columns:repeat(6,1fr);gap:2px;margin:12px 0 18px}
+  .riskmx .lab{font-family:var(--mono);font-size:10px;color:var(--muted);padding:6px;text-align:center}
+  .riskmx .cell{border:1px solid var(--line);background:#fff;min-height:56px;padding:4px;font-size:10.5px;line-height:1.35;position:relative}
+  .riskmx .cell.lo{background:#f4f8f4}
+  .riskmx .cell.md{background:#fbf4e1}
+  .riskmx .cell.hi{background:#fbe4e4}
+  .riskmx .cell .tag{font-family:var(--mono);font-size:9px;color:var(--ink-2);background:#fff;border:1px solid var(--line);padding:0 4px;display:inline-block;margin-bottom:2px}
+
+  /* ---- Timeline strip ---- */
+  .tline{margin:14px 0 18px}
+  .tline .evt{display:grid;grid-template-columns:96px 12px 1fr;gap:10px;align-items:start;padding:6px 0;border-bottom:1px dashed var(--line)}
+  .tline .evt:last-child{border-bottom:0}
+  .tline .d{font-family:var(--mono);font-size:11px;color:var(--muted)}
+  .tline .m{width:10px;height:10px;margin-top:6px;border-radius:50%;background:var(--accent);border:2px solid var(--panel);box-shadow:0 0 0 1px var(--accent)}
+  .tline .evt.major .m{background:var(--warn);box-shadow:0 0 0 1px var(--warn)}
+  .tline .evt.minor .m{background:var(--muted);box-shadow:0 0 0 1px var(--muted)}
+  .tline .txt{font-size:13.5px;color:var(--ink-2)}
+
+  /* ---- Gantt ---- */
+  .gantt{margin:12px 0 18px;font-size:12px}
+  .gantt .row{display:grid;grid-template-columns:160px 1fr;gap:10px;align-items:center;margin-bottom:5px}
+  .gantt .row .l{color:var(--ink-2)}
+  .gantt .row .track{background:#ece9e0;height:14px;position:relative;border:1px solid var(--line)}
+  .gantt .row .track .seg{position:absolute;top:0;bottom:0;background:var(--accent);color:#fff;font-family:var(--mono);font-size:9.5px;letter-spacing:.04em;padding:0 5px;line-height:12px}
+  .gantt .row .track .seg.c2{background:var(--chart-2);color:#1a1a1a}
+  .gantt .row .track .seg.c3{background:var(--chart-3);color:#fff}
+  .gantt .row .track .seg.ghost{background:repeating-linear-gradient(45deg,#d8d4c8,#d8d4c8 4px,#ece9e0 4px,#ece9e0 8px);color:var(--muted)}
+  .gantt .q{display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:2px;font-family:var(--mono);font-size:10px;color:var(--muted);margin-bottom:4px}
+  .gantt .q span{text-align:center}
+
+  @media print{
+    body{background:#fff}
+    .lang-toggle{display:none}
+    .wrap{max-width:none;padding:0}
+    h2.section{page-break-before:auto}
+    a{color:var(--ink)}
+    figure.viz{break-inside:avoid}
+  }
+
+  /* ========= POLISH · readability & rhythm ========= */
+
+  /* 1) Body text — slightly looser line-height for longer passages; Korean-aware word breaking */
+  body{line-height:1.74}
+  p, li{word-break:keep-all;overflow-wrap:anywhere}
+  code{word-break:break-all}
+
+  /* 2) Stronger vertical rhythm between sections */
+  h2.section{
+    margin-top:72px;
+    padding-top:30px;
+    border-top:1px solid var(--line-2);
+  }
+  h2.section:first-of-type{margin-top:48px}
+
+  /* 3) Section number — clearer visual hierarchy */
+  h2.section .num{
+    color:var(--accent);
+    font-weight:500;
+    min-width:58px;
+  }
+
+  /* 4) h3/h4 spacing + keep-with-next */
+  h3{margin:32px 0 12px;page-break-after:avoid;break-after:avoid}
+  h4{margin:22px 0 10px;page-break-after:avoid;break-after:avoid;color:var(--ink)}
+  h5{margin:20px 0 8px;page-break-after:avoid;break-after:avoid}
+
+  /* 5) Lead paragraphs — more breathing room */
+  .lead{font-size:17.5px;line-height:1.7;margin-bottom:16px}
+
+  /* 6) Lists — better internal spacing */
+  ul, ol{margin:0 0 16px 0;padding-left:24px}
+  ul li, ol li{margin-bottom:8px;line-height:1.7}
+  ul li > ul, ol li > ol{margin-top:6px;margin-bottom:4px}
+
+  /* 7) Tables — cleaner vertical padding, stripe background, hover cue */
+  table{font-size:14.5px;margin:16px 0 22px}
+  th{
+    padding:12px 12px 10px;
+    font-size:11.5px;
+    background:#f7f5ef;
+    border-bottom:1.5px solid var(--line-2);
+    vertical-align:bottom;
+  }
+  td{padding:11px 12px;line-height:1.65}
+  tr:hover td{background:#fbf9f2}
+  tbody tr:last-child td{border-bottom:0}
+  td strong{color:var(--ink)}
+
+  /* 8) KPI cells — subtle hover, clearer value spacing */
+  .kpi .cell{padding:16px 16px 14px;transition:border-color .15s, background .15s}
+  .kpi .cell:hover{border-color:var(--line-2);background:#fdfbf5}
+  .kpi .value{font-size:24px;letter-spacing:-0.01em}
+  .kpi .label{margin-bottom:8px}
+  .kpi .unit{line-height:1.5}
+
+  /* 9) Callouts — softer, more generous spacing */
+  .callout{padding:16px 20px;margin:16px 0 22px;border-radius:2px}
+  .callout p{margin:0}
+  .callout p + p{margin-top:8px}
+  .callout-title{margin-bottom:8px}
+
+  /* 10) Figures / visualizations — consistent spacing and page-break control */
+  figure.viz{
+    margin:20px 0 26px;
+    padding:22px 22px 16px;
+    page-break-inside:avoid;
+    break-inside:avoid;
+  }
+  figure.viz figcaption{
+    margin-top:12px;
+    font-family:var(--sans);
+    font-size:13px;
+    color:var(--muted);
+    letter-spacing:0;
+    text-transform:none;
+    line-height:1.55;
+  }
+  figure.viz figcaption::first-letter{letter-spacing:0}
+
+  /* 11) Screenshot plates — cleaner caption, consistent spacing */
+  figure.plate{margin:20px 0 26px;page-break-inside:avoid;break-inside:avoid}
+  figure.plate figcaption{
+    padding:10px 16px;
+    font-family:var(--sans);
+    font-size:13px;
+    text-transform:none;
+    letter-spacing:0;
+    line-height:1.55;
+  }
+
+  /* 12) Kicker / monospace labels — consistent treatment */
+  .fig-label, figure.viz figcaption .fig-label{
+    font-family:var(--mono);
+    font-size:11px;
+    letter-spacing:.1em;
+    text-transform:uppercase;
+    color:var(--muted);
+  }
+
+  /* 13) Section snapshot card — more generous */
+  .snap{padding:24px 26px;margin:0 0 34px}
+
+  /* 14) TOC — slightly roomier */
+  .toc{padding:20px 24px}
+  .toc a{padding:4px 0}
+
+  /* 15) Language toggle — clearer affordance */
+  .lang-toggle button{transition:background .15s, color .15s}
+  .lang-toggle button:hover:not(.active){background:#f2efe9;color:var(--ink)}
+
+  /* 16) Timeline rows — better spacing */
+  .tline .evt{padding:8px 0}
+  .tline .txt{line-height:1.65}
+
+  /* 17) Gantt — crisper */
+  .gantt{margin:14px 0 22px;font-size:12px}
+  .gantt .row{margin-bottom:6px}
+  .gantt .row .track{height:16px}
+  .gantt .row .track .seg{line-height:14px;padding:0 6px}
+
+  /* 18) Repos tile grid — slight refinement */
+  .repos{gap:5px;margin:14px 0 22px}
+  .repos .tile{padding:8px 8px 6px}
+  .repos .tile .n{font-size:10px}
+  .repos .tile .m{font-size:9px}
+
+  /* 19) Exchange card — consistent with util/posts cards */
+  .exlist{gap:12px}
+  .exlist .ex{padding:14px 16px;transition:border-color .15s, background .15s}
+  .exlist .ex:hover{border-color:var(--line-2);background:#fdfbf5}
+
+  /* 20) Links — consistent underline-on-hover */
+  a{transition:color .15s, border-color .15s}
+
+  /* 21) Small text / captions — softer gray */
+  .small{line-height:1.6}
+
+  /* 22) Horizontal rule softening */
+  hr{border-top-color:var(--line-2);margin:36px 0}
+
+  /* 23) Chips (signal adapters) */
+  .chips{gap:6px 7px;margin:12px 0 18px}
+  .chips .c{padding:4px 10px;line-height:1.5}
+
+  /* 24) Mono stat cells — align numbers */
+  td.num{font-variant-numeric:tabular-nums}
+
+  /* 25) Responsive tweaks for narrow screens */
+  @media(max-width:760px){
+    .wrap{padding:28px 18px 80px}
+    h1.title{font-size:30px;line-height:1.18}
+    h2.section{margin-top:52px;padding-top:24px;font-size:22px}
+    h2.section .num{display:block;margin-bottom:4px;min-width:0}
+    h3{font-size:17px}
+    .snap{padding:18px 18px;margin-bottom:24px}
+    figure.viz{padding:16px}
+    table{font-size:12.5px}
+    th, td{padding:8px 8px}
+    .kpi .value{font-size:20px}
+    .lead{font-size:16px}
+    .clusters{grid-template-columns:repeat(2,1fr) !important}
+  }
+
+  /* 26) Keep-together for short structures */
+  .callout, figure.viz, figure.plate, .snap, .kpi{page-break-inside:avoid;break-inside:avoid}
+
+  /* ========= MOBILE — responsive tables & cards ========= */
+
+  /* 28) Mobile — convert tables to stacked cards with data-label headers */
+  @media(max-width:720px){
+    /* Tables: block-based card layout */
+    table, table tbody, table tr, table td{
+      display:block;
+      width:100%;
+      box-sizing:border-box;
+    }
+    table{margin:14px 0 20px}
+    table colgroup{display:none}
+    table thead{display:none}
+    table tbody tr{
+      border:1px solid var(--line);
+      background:#fff;
+      padding:12px 14px;
+      margin-bottom:10px;
+      border-radius:2px;
+    }
+    table tbody tr:hover{background:#fff} /* disable desktop hover */
+    table td{
+      border:0 !important;
+      padding:5px 0 !important;
+      line-height:1.6;
+      text-align:left !important;
+      white-space:normal !important;
+      overflow-wrap:anywhere;
+      word-break:break-word;
+    }
+    /* Label from thead (auto-populated by JS) */
+    table td[data-label]::before{
+      content:attr(data-label) " · ";
+      display:inline;
+      font-family:var(--mono);
+      font-size:10px;
+      letter-spacing:.08em;
+      text-transform:uppercase;
+      color:var(--muted);
+      margin-right:6px;
+      font-weight:500;
+    }
+    /* First td: no label prefix, treat as card title */
+    table td:first-child[data-label]::before{display:none}
+    table td:first-child{
+      font-weight:600;
+      color:var(--ink);
+      font-size:14px;
+      padding-bottom:4px !important;
+      margin-bottom:4px;
+      border-bottom:1px dashed var(--line) !important;
+      border-bottom-width:1px !important;
+    }
+    /* Numeric cells */
+    table td.num{
+      font-family:var(--mono);
+      text-align:left !important;
+    }
+
+    /* 29) §4.2 Posts cards — always single column, disable grid-column span */
+    .posts{grid-template-columns:1fr !important;gap:14px}
+    .posts .p{grid-column:auto !important}
+    .posts .p .t{font-size:15px;line-height:1.4}
+
+    /* 30) Exchange card 2x2 → 1-column on narrow mobile */
+    @media(max-width:560px){
+      .exlist{grid-template-columns:1fr !important}
+      .util{grid-template-columns:1fr !important}
+    }
+
+    /* 31) Clusters (agent groupings) — 2 col on small mobile */
+    .clusters{grid-template-columns:repeat(2,1fr) !important}
+    .clusters .c{font-size:14px}
+    .clusters .m{font-size:10.5px}
+
+    /* 32) KPI grid — 2 col on mobile, text sizes down */
+    .kpi, .kpi.three, .kpi.six{grid-template-columns:repeat(2,1fr) !important}
+    .kpi .value{font-size:19px}
+    .kpi .label{font-size:9.5px}
+    .kpi .unit{font-size:11px}
+
+    /* 33) Repos tile grid: 3 col on narrow */
+    .repos{grid-template-columns:repeat(3,1fr) !important}
+    .repos .tile{padding:6px 6px 4px}
+
+    /* 34) Bars chart: readjust label width */
+    .bars .row{grid-template-columns:110px 1fr 52px;font-size:12px;gap:8px}
+
+    /* 35) Gantt: readjust label width */
+    .gantt .row{grid-template-columns:120px 1fr;gap:6px;font-size:11px}
+
+    /* 36) Timeline: tighter */
+    .tline .evt{grid-template-columns:78px 12px 1fr;gap:8px}
+    .tline .d{font-size:10.5px}
+    .tline .txt{font-size:12.5px}
+
+    /* 37) Chips — smaller */
+    .chips .c{padding:3px 8px;font-size:10px}
+
+    /* 38) Risk matrix — stack rows as blocks */
+    .riskmx{grid-template-columns:1fr !important;gap:6px}
+    .riskmx .lab{display:none}
+    .riskmx .cell{min-height:auto;padding:8px 10px}
+
+    /* 39) SVG figures — scale to fit */
+    figure.viz svg, figure.plate svg{max-width:100%;height:auto}
+    figure.viz{padding:12px 10px 10px}
+    figure.plate .img{aspect-ratio:1.6/1}
+
+    /* 40) Snapshot card, callout — tighter */
+    .snap{padding:16px 14px}
+    .callout{padding:12px 14px}
+
+    /* 41) Cover note — mobile padding */
+    .cover-note{padding:14px 16px}
+
+    /* 42) Exchange card, post card — readable mobile */
+    .exlist .ex, .util .u, .posts .p{padding:12px 14px}
+
+    /* 43) Terminal mock (§4.4) — stats go 2-col, ASCII tree horizontally scrollable */
+    .mock{font-size:10px;padding:12px 14px;overflow-x:auto;-webkit-overflow-scrolling:touch}
+    .mock .stat{grid-template-columns:repeat(2,1fr) !important;gap:10px}
+    .mock .stat .s .k{font-size:9px}
+    .mock .stat .s .v{font-size:13px;word-break:break-all;line-height:1.25}
+    /* Tree lines (├── └──) preserved on monospace line with horizontal scroll */
+    .mock > div{white-space:nowrap}
+    .mock > div.stat{white-space:normal}
+    /* But let value cells (numbers) wrap */
+    .mock .stat .s .v{white-space:normal}
+
+    /* 44) Pre/code blocks (pseudocode in §A.3) — smaller on mobile, scroll */
+    pre.mono{font-size:10px !important;padding:10px 12px !important;overflow-x:auto;white-space:pre !important}
+
+    /* 45) Footer social links — allow wrapping and better readability */
+    footer p{line-height:1.9}
+    footer a{display:inline-block;margin-right:2px}
+
+    /* 46) Chips — smaller gaps on very narrow */
+    .chips{gap:5px}
+    .chips .c{font-size:10px;padding:2px 7px}
+
+    /* 47) Lang-toggle — full-width single row, 3 equal buttons */
+    .lang-toggle{display:flex;width:100%;max-width:none}
+    .lang-toggle button{flex:1 1 0;text-align:center;padding:6px 4px;white-space:nowrap;min-width:0}
+
+    /* 48) Cover meta grid — 2x2 stays but smaller */
+    .meta{font-size:12px;gap:8px 16px}
+    .meta dt{font-size:9px}
+  }
+
+  @media(max-width:520px){
+    .mock .stat{grid-template-columns:1fr !important}
+    .mock .stat .s .v{font-size:14px}
+  }
+
+  /* ========= END MOBILE ========= */
+
+  /* 27) Cover note — report scope paragraph, styled as secondary IR note */
+  .cover-note{
+    margin-top:22px;
+    padding:16px 20px;
+    border-left:2px solid var(--line-2);
+    background:#fcfbf7;
+    font-size:13px;
+    line-height:1.68;
+    color:var(--ink-2);
+  }
+  .cover-note p{margin:0}
+  .cover-note p + p{margin-top:10px;padding-top:10px;border-top:1px dashed var(--line)}
+  body.only-ko .cover-note p.lang-en{display:none}
+  body.only-en .cover-note p.lang-ko{display:none}
+  body.only-ko .cover-note p.lang-ko,
+  body.only-en .cover-note p.lang-en{color:var(--ink-2);font-size:13px;line-height:1.68}
+  body.only-ko .cover-note p + p,
+  body.only-en .cover-note p + p{border-top:0;padding-top:0;margin-top:0}
+
+
+/* ===== Verifiability tiers & private-repository lock badges ===== */
+.lock{display:inline-block;background:#f1efe9;color:#5b6068;border:1px solid var(--line-2);border-radius:4px;font-size:10.5px;padding:1px 7px;margin-left:4px;font-family:var(--mono);white-space:nowrap}
+.vb{display:inline-block;border-radius:3px;font-size:10px;padding:0 6px;margin-left:5px;font-family:var(--mono);font-weight:600;border:1px solid;vertical-align:middle;white-space:nowrap}
+.vb.v1{color:var(--accent);border-color:#bcd6d0;background:var(--accent-soft)}
+.vb.v2{color:#6a5a20;border-color:#e0d3a0;background:#f7f0da}
+.vb.v3{color:#5b6068;border-color:var(--line-2);background:#f1efe9}
+.lang-toggle button[disabled]{opacity:.4;cursor:not-allowed}
+
+/* mobile: let figures keep their natural size and scroll, instead of shrinking
+   9-11px SVG text to ~4px. Caption stays at viewport width. */
+@media(max-width:720px){
+  figure.viz{padding:12px 10px 10px}
+  figure.viz .vizscroll{overflow-x:auto;-webkit-overflow-scrolling:touch;margin-bottom:8px}
+  figure.viz .vizscroll svg{width:660px;min-width:660px;max-width:none;height:auto;display:block}
+  /* 표지 Hero는 데이터 도표가 아니라 단순 다이어그램이므로 스크롤 대신 축소 */
+  header.cover figure.viz .vizscroll{overflow-x:visible}
+  header.cover figure.viz .vizscroll svg{width:100%;min-width:0;max-width:100%}
+}
+
+/* EN-only mode: .lang-en is a small muted subtitle for the bilingual view; inside a
+   heading or a table cell that flattens the typography.  Restore the host's own. */
+body.only-en h1 .lang-en, body.only-en h2 .lang-en, body.only-en h3 .lang-en,
+body.only-en h4 .lang-en, body.only-en h5 .lang-en, body.only-en h6 .lang-en,
+body.only-en th .lang-en, body.only-en td .lang-en{
+  display:inline;font-size:inherit;color:inherit;line-height:inherit;margin:0
+}
+
+/* Gantt segment labels live inside a 16px absolutely-positioned bar. The .lang-en
+   subtitle treatment (block, 14-15px, ink) would push them out of the bar and across the
+   neighbouring rows, so labels keep the bar's own type, never wrap, and only one language
+   shows inside a bar — two will not fit. Scoped per mode so the hide rules still win. */
+.gantt .seg .lang-ko, .gantt .seg .lang-en{
+  font:inherit;color:inherit;line-height:inherit;margin:0;white-space:nowrap
+}
+body:not(.only-en) .gantt .seg .lang-ko{display:inline}
+body:not(.only-en) .gantt .seg .lang-en{display:none}
+body.only-en .gantt .seg .lang-ko{display:none}
+body.only-en .gantt .seg .lang-en{display:inline}
+</style>
+</head>
+<body class="only-ko">
+<div class="wrap">
+
+<!-- ================= COVER ================= -->
+<header class="cover">
+  <div class="kicker">Mossland Foundation — Quarterly Activity &amp; Disclosure Report</div>
+  <h1 class="title">2026년 2분기 활동 리포트</h1>
+  <div class="subtitle">Reality Enters the Loop · 2026 Q2 Activity &amp; Disclosure Report · v1.0</div>
+
+  <!-- Hero SVG — Q1 "Invisible Bridge" 루프의 연속. Q2는 REALITY 노드가 실제로 켜진 분기 -->
+  <figure class="viz" style="background:#f7f5ef;border-color:#e4e2dc;padding:0;margin:24px 0 20px">
+    <div class="vizscroll"><svg viewBox="0 0 900 210" role="img" aria-label="Governance loop — reality node now live">
+      <path d="M 80 150 Q 450 10 820 150" fill="none" stroke="#15665c" stroke-width="1.2" opacity="0.45"/>
+      <line x1="60" y1="150" x2="840" y2="150" stroke="#e4e2dc" stroke-width="1" stroke-dasharray="1 3"/>
+      <!-- REALITY node: now live (pulse ring) -->
+      <circle cx="80" cy="150" r="14" fill="none" stroke="#c68f2a" stroke-width="1" opacity="0.5"/>
+      <circle cx="80" cy="150" r="19" fill="none" stroke="#c68f2a" stroke-width="0.7" opacity="0.25"/>
+      <g>
+        <circle cx="80"  cy="150"  r="9"  fill="#c68f2a" stroke="#f7f5ef" stroke-width="3"/>
+        <circle cx="265" cy="97.5" r="7"  fill="#8a5e3c" stroke="#f7f5ef" stroke-width="3"/>
+        <circle cx="450" cy="80"   r="10" fill="#15665c" stroke="#f7f5ef" stroke-width="3"/>
+        <circle cx="635" cy="97.5" r="7"  fill="#6a7a8d" stroke="#f7f5ef" stroke-width="3"/>
+        <circle cx="820" cy="150"  r="8"  fill="#0d4a43" stroke="#f7f5ef" stroke-width="3"/>
+      </g>
+      <g stroke="#cecac1" stroke-width="1" stroke-dasharray="1 2">
+        <line x1="265" y1="107" x2="265" y2="150"/>
+        <line x1="450" y1="93"  x2="450" y2="150"/>
+        <line x1="635" y1="107" x2="635" y2="150"/>
+      </g>
+      <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" fill="#5b6068" letter-spacing="0.14em">
+        <text x="80"  y="180" text-anchor="middle" fill="#8a6500" font-weight="bold">REALITY · CONNECTED</text>
+        <text x="265" y="180" text-anchor="middle">MINING</text>
+        <text x="450" y="180" text-anchor="middle">CONSENSUS</text>
+        <text x="635" y="180" text-anchor="middle">DECISION</text>
+        <text x="820" y="180" text-anchor="middle">OUTCOME</text>
+      </g>
+      <text x="450" y="30" font-family="Iowan Old Style, Sitka Text, Georgia, serif" font-size="14" font-style="italic" fill="#5b6068" text-anchor="middle">
+        real buildings, real signals, real addresses &nbsp;—&nbsp; the loop's first node is now live
+      </text>
+    </svg></div>
+  </figure>
+
+  <dl class="meta">
+    <div><dt>보고 기간 · Period</dt><dd>2026-04-01 — 2026-06-30</dd></div>
+    <div><dt>발행일 · Issued</dt><dd><span class="lang-ko">2026-08-04 · 데이터 스냅샷 2026-08-03</span><span class="lang-en">2026-08-04 · Data snapshot 2026-08-03</span></dd></div>
+    <div><dt>발행 주체 · Issuer</dt><dd>Mossland Foundation</dd></div>
+    <div><dt>토큰 · Token</dt><dd>MOC (ERC-20)</dd></div>
+  </dl>
+
+  <div style="margin-top:22px">
+    <div class="lang-toggle" role="tablist" aria-label="언어 선택">
+      <button data-lang="ko" class="active">KO</button>
+      <button data-lang="both">KO + EN</button>
+      <button data-lang="en">EN</button>
+    </div>
+    <p class="small muted" style="margin-top:8px"><span class="lang-ko">한국어·영어 병기본입니다. 위 버튼으로 표시 언어를 전환할 수 있습니다. 해석에 차이가 있을 경우 한국어본이 우선합니다 (§D).</span><span class="lang-en">A bilingual edition. Use the buttons above to switch the display language. Where interpretations differ, the Korean text prevails (§D).</span></p>
+  </div>
+
+  <div class="cover-note">
+    <p class="small lang-ko" style="margin-top:-8px">표지 도식의 <strong>&ldquo;REALITY · CONNECTED&rdquo;</strong>는 내부 실건물 신호가 트윈에 연결된 상태를 뜻하며, <strong>AX Sprint 실증 착수나 고객 생산환경 배포를 의미하지 않습니다</strong>(§7.1).</p><p class="small lang-en" style="margin-top:-8px"><strong>&ldquo;REALITY · CONNECTED&rdquo;</strong> on the cover diagram means that signals from a real building are connected to the twin; it <strong>does not mean that AX Sprint pilots have begun or that anything has been deployed to a customer production environment</strong> (§7.1).</p>
+    <p class="lang-ko">본 리포트는 Mossland Foundation이 모스코인(MOC) 홀더와 프로젝트에 관심 있는 모든 분을 대상으로 작성한 분기 활동·공시 자료입니다. <strong>보고 범위는 재단 단독 실적이 아니라, 모스랜드가 관리하는 GitHub 네임스페이스와 <span class="mono">*.moss.land</span> 서비스에서 관찰된 생태계 활동입니다</strong> — 개발 활동 수치에는 재단 외 법인이 수행·부담했을 수 있는 활동이 포함되며, 고용 법인·비용 부담·지식재산 귀속은 본 리포트가 확정하지 않습니다(§6.3). 주요 정량 수치는 GitHub API·공시 대시보드(<a href="https://disclosure.moss.land" target="_blank" rel="noopener">disclosure.moss.land</a>)·공개 데이터 소스와 <strong>재단 내부 집계</strong>에서 도출되며, 외부 검증 가능성은 V1·V2·V3 등급으로 구분해 §A에 정의했습니다.</p><p class="lang-en">This report is the quarterly activity and disclosure record prepared by the Mossland Foundation for MossCoin (MOC) holders and anyone following the project. <strong>Its reporting scope is not the Foundation's sole performance but the ecosystem activity observed across the GitHub namespaces Mossland administers and the <span class="mono">*.moss.land</span> services</strong> — the development figures may include work performed or funded by entities other than the Foundation, and this report does not determine the employing entity, who bore the cost, or ownership of intellectual property (§6.3). Principal quantitative figures are derived from the GitHub API, the disclosure dashboard (<a href="https://disclosure.moss.land" target="_blank" rel="noopener">disclosure.moss.land</a>), public data sources and <strong>the Foundation's internal aggregation</strong>; external verifiability is graded V1 · V2 · V3 and defined in §A.</p>
+  </div>
+</header>
+
+<!-- ================= AT A GLANCE ================= -->
+<section class="snap">
+  <h4><span class="lang-ko">한눈에 보기</span><span class="lang-en">At a Glance</span></h4>
+  <div class="kpi">
+    <div class="cell"><div class="label">MOC Market Cap</div><div class="value">₩11.57B</div><div class="unit"><span class="lang-ko">≈ USD 7.46M · 2026-06-30 분기말 <span class="vb v1">V1</span></span><span class="lang-en">≈ USD 7.46M · quarter-end 2026-06-30 <span class="vb v1">V1</span></span></div></div>
+    <div class="cell"><div class="label">Circulating Supply</div><div class="value">448.49M</div><div class="unit"><span class="lang-ko">최대 500M의 89.70% · 보고·추정값 <span class="vb v2">V2</span></span><span class="lang-en">89.70% of the 500M maximum · reported/estimated <span class="vb v2">V2</span></span></div></div>
+    <div class="cell"><div class="label">Q2 Official Disclosures</div><div class="value">2</div><div class="unit"><span class="lang-ko">04-21 컨소시엄 · 06-11 판결 <span class="vb v1">V1</span></span><span class="lang-en">04-21 consortium · 06-11 judgment <span class="vb v1">V1</span></span></div></div>
+    <div class="cell"><div class="label">Q2 Blog Posts</div><div class="value">19</div><div class="unit"><span class="lang-ko">12개 주제 · KO/EN 동일일 페어 7 <span class="vb v1">V1</span></span><span class="lang-en">12 topics · 7 same-day KO/EN pairs <span class="vb v1">V1</span></span></div></div>
+  </div>
+  <div class="kpi">
+    <div class="cell"><div class="label">Tracked GitHub Activity (3 namespaces)</div><div class="value">1,945</div><div class="unit"><span class="lang-ko">공개 259 · 비공개 1,686 · 관찰된 활동량 <span class="vb v3">V3</span></span><span class="lang-en">public 259 · private 1,686 · observed activity <span class="vb v3">V3</span></span></div></div>
+    <div class="cell"><div class="label">Commit-active Repos</div><div class="value">45</div><div class="unit"><span class="lang-ko">Q2 커밋 발생 저장소 · 저장소 재고 93(2026-08-03 시점)</span><span class="lang-en">repositories with Q2 commits · 93 repositories on record (as of 2026-08-03)</span></div></div>
+    <div class="cell"><div class="label">Live Domains (Q2-END)</div><div class="value">18</div><div class="unit"><span class="lang-ko">*.moss.land · 독립 서비스 17 · MAIT 종료 후 07-06 기준 17/16 <span class="vb v2">V2</span></span><span class="lang-en">*.moss.land · 17 independent services · 17/16 on the 07-06 list after MAIT ended <span class="vb v2">V2</span></span></div></div>
+    <div class="cell"><div class="label">DAO Proposals (Q2)</div><div class="value">0</div><div class="unit"><span class="lang-ko">누적 41 · 7/8 신규 제안은 §12</span><span class="lang-en">41 cumulative · the 7/8 new proposal is in §12</span></div></div>
+  </div>
+  <p class="small" style="margin-bottom:0">
+    <span class="lang-ko">커밋 수치는 이번 분기부터 3개 GitHub 네임스페이스(mossland · MosslandOpenDevs · MosslandCore)·비공개 저장소 포함으로 집계 범위가 확장되었습니다. 기준 변경의 상세와 전분기 대비 가능성은 §6.1을 참조하십시오. Q1에 제시한 목표 대비 실적은 §1.2 스코어카드에 정리했습니다.</span><span class="lang-en">From this quarter the commit figures cover three GitHub namespaces (mossland · MosslandOpenDevs · MosslandCore) and include private repositories. See §6.1 for the change in basis and what can still be compared with the previous quarter. Performance against the targets set in Q1 is recorded in the §1.2 scorecard.</span>
+  </p>
+</section>
+
+<!-- ================= TOC ================= -->
+<section id="toc" aria-label="목차">
+  <h4 style="margin-bottom:8px"><span class="lang-ko">목차</span><span class="lang-en">Table of Contents</span></h4>
+  <nav class="toc">
+    <a href="#s1"><span class="num">§1.</span> <span class="lang-ko">경영 요약 · 스코어카드</span><span class="lang-en">Executive Summary &amp; Scorecard</span></a>
+    <a href="#s2"><span class="num">§2.</span> <span class="lang-ko">토큰 공시 (MOC)</span><span class="lang-en">Token Disclosure (MOC)</span></a>
+    <a href="#s3"><span class="num">§3.</span> <span class="lang-ko">분기 맥락과 전략 방향</span><span class="lang-en">Quarter Context &amp; Strategy</span></a>
+    <a href="#s4"><span class="num">§4.</span> <span class="lang-ko">커뮤니케이션 · 공시</span><span class="lang-en">Communications &amp; Disclosures</span></a>
+    <a href="#s5"><span class="num">§5.</span> <span class="lang-ko">서비스 카탈로그</span><span class="lang-en">Service Catalog</span></a>
+    <a href="#s6"><span class="num">§6.</span> <span class="lang-ko">기술 개발 현황</span><span class="lang-en">Technical Development</span></a>
+    <a href="#s7"><span class="num">§7.</span> <span class="lang-ko">핵심 프로젝트 심층</span><span class="lang-en">Core Projects</span></a>
+    <a href="#s8"><span class="num">§8.</span> <span class="lang-ko">커뮤니티 · 오픈소스</span><span class="lang-en">Community &amp; OSS</span></a>
+    <a href="#s9"><span class="num">§9.</span> <span class="lang-ko">거버넌스 · 법적 사항</span><span class="lang-en">Governance &amp; Legal</span></a>
+    <a href="#s10"><span class="num">§10.</span> <span class="lang-ko">리스크 요인</span><span class="lang-en">Risk Factors</span></a>
+    <a href="#s11"><span class="num">§11.</span> <span class="lang-ko">분기 핵심 인사이트</span><span class="lang-en">Key Insights</span></a>
+    <a href="#s12"><span class="num">§12.</span> <span class="lang-ko">분기 이후 경과</span><span class="lang-en">Subsequent Events</span></a>
+    <a href="#s13"><span class="num">§13.</span> <span class="lang-ko">3분기 방향성 · 로드맵</span><span class="lang-en">Outlook · Q3</span></a>
+    <a href="#appA"><span class="num">§A.</span> <span class="lang-ko">데이터 출처 및 방법론</span><span class="lang-en">Sources &amp; Methodology</span></a>
+    <a href="#appB"><span class="num">§B.</span> <span class="lang-ko">AI 보조 작성 고지</span><span class="lang-en">AI Authoring Notice</span></a>
+    <a href="#appC"><span class="num">§C.</span> <span class="lang-ko">용어 해설</span><span class="lang-en">Glossary</span></a>
+    <a href="#safeharbor"><span class="num">§D.</span> <span class="lang-ko">미래예측 진술 고지</span><span class="lang-en">Forward-Looking Statements</span></a>
+  </nav>
+</section>
+
+<!-- ================= §1 ================= -->
+<h2 class="section" id="s1"><span class="num">§1</span><span class="lang-ko">경영 요약 · 스코어카드</span><span class="lang-en">Executive Summary &amp; Scorecard</span></h2>
+
+<h3 id="s1.1">1.1 <span class="lang-ko">핵심 요약 — 다섯 가지</span><span class="lang-en">Key Takeaways — Five Points</span></h3>
+<ol>
+  <li><span class="lang-ko"><strong>실험이 주소를 갖게 되었습니다.</strong> 1분기에 저장소 안에 있던 실험들이 2분기에 <code>*.moss.land</code> 라이브 서비스로 나왔습니다. Alpha · Signal Map · Media · City · NPC · Recipe(5월, AI 미디어 클러스터), links(6/29), Passport(6/30 오픈베타)가 새로 공개되어 <strong>분기말 기준 라이브 도메인은 18개</strong>입니다 — 7월 초 종료된 MAIT를 포함한 수치이며, MAIT 종료 후 현재 목록(2026-07-06 확인) 기준으로는 17개입니다. (§5)</span><span class="lang-en"><strong>The experiments got addresses.</strong> What sat inside repositories in Q1 came out as live <code>*.moss.land</code> services in Q2. Alpha · Signal Map · Media · City · NPC · Recipe (May, the AI media cluster), links (6/29) and Passport (6/30 open beta) were newly published, bringing <strong>live domains at quarter-end to 18</strong> — a figure that includes MAIT, which ended in early July; on the current list (verified 2026-07-06) it is 17. (§5)</span></li>
+  <li><span class="lang-ko"><strong>분기 개발의 무게중심은 디지털 트윈이었습니다.</strong> 전체 커밋 1,945건 중 1,086건(55.8%)이 디지털 트윈 트랙(렌더링·변환 엔진 + 실건물 운영 트윈)에서 발생했으며, 4/21 국토부 AX Sprint R&amp;D 컨소시엄 참여 공시 및 6/25 선정 발표(§7.1)와 같은 축 위에 있습니다. (§7.1)</span><span class="lang-en"><strong>The quarter's centre of development gravity was the digital twin.</strong> Of 1,945 commits in total, 1,086 (55.8%) were recorded in the digital twin track (rendering/conversion engine plus the live-building operations twin), on the same axis as the 4/21 disclosure of participation in the MOLIT AX Sprint R&amp;D consortium and the 6/25 selection announcement (§7.1). (§7.1)</span></li>
+  <li><span class="lang-ko"><strong>홀더 참여 인프라를 다시 세웠습니다.</strong> Passport가 6/9 개발 착수 후 3주 만에 v1.6·오픈베타에 도달했고, Agora는 6/25부터 인증·보안 기반 재정비에 착수했으며, MAIT는 최신 스택으로 현대화한 뒤 통합·종료로 방향을 정했습니다. 2분기 중 신규 거버넌스 제안은 0건이었고, 같은 기간 이 재정비가 진행되었습니다. 두 현상의 인과는 단정하지 않으며, 재정비 이후인 7/8 신규 제안이 상정되었습니다. (§7.2–7.3, §9.3, §12)</span><span class="lang-en"><strong>Holder participation infrastructure was rebuilt.</strong> Passport went from development start on 6/9 to v1.6 and open beta within three weeks; Agora began rebuilding its authentication and security foundations on 6/25; and MAIT was modernised onto a current stack before the decision was taken to consolidate and retire it. There were no new governance proposals during Q2, and this rebuilding took place over the same period; no causal link between the two is asserted. A new proposal was tabled on 7/8, after the rebuilding. (§7.2–7.3, §9.3, §12)</span></li>
+  <li><span class="lang-ko"><strong>집계 기준을 확장했고, 공개 커밋 목표는 미달했습니다.</strong> 이번 분기부터 집계 범위를 3개 GitHub 네임스페이스·비공개 저장소 포함으로 확장해 총 1,945커밋을 공시합니다(비공개 86.7%). 다만 Q1에 제시한 "공개 커밋 ≥500" 목표는 259건으로 미달했습니다. 원인과 지표 재설계는 §1.2와 §6.1에 정리했습니다.</span><span class="lang-en"><strong>The counting basis was widened, and the public-commit target was missed.</strong> From this quarter the scope covers three GitHub namespaces including private repositories, giving a disclosed total of 1,945 commits (86.7% private). The Q1 target of "public commits ≥ 500" was, however, missed at 259. The causes and the redesign of the indicator are set out in §1.2 and §6.1.</span></li>
+  <li><span class="lang-ko"><strong>2024년 소송 트랙이 최종 종결되었습니다.</strong> 6/11 대법원이 원고 상고를 기각하여 피고(손OO 개인) 승소로 확정되었습니다. 재단은 본 소송의 당사자가 아니며, 관련 법적 리스크는 하향 조정합니다. (§9.1, §10)</span><span class="lang-en"><strong>The 2024 litigation track reached final conclusion.</strong> On 6/11 the Supreme Court dismissed the plaintiff's appeal, confirming the outcome in favour of the defendant (Mr./Ms. Son, an individual). The Foundation is not a party to this litigation, and the related legal risk is revised downward. (§9.1, §10)</span></li>
+</ol>
+
+<h3 id="s1.2">1.2 <span class="lang-ko">Q1 목표 대비 스코어카드</span><span class="lang-en">Scorecard vs. Q1 Targets</span></h3>
+<p class="lang-ko">1분기 리포트 §11에서 제시한 2분기 목표에 대한 자체 평가입니다. 목표를 제시했으면 결과를 보고하는 것이 본 리포트 체계의 원칙이며, 미달 항목도 그대로 기재합니다.</p><p class="lang-en">A self-assessment against the Q2 targets set out in §11 of the Q1 report. Reporting the outcome of any target that was set is a principle of this report's framework, and items that were missed are recorded as such.</p>
+
+<table>
+  <thead><tr><th>#</th><th><span class="lang-ko">Q1이 제시한 목표 (정성)</span><span class="lang-en">Target set in Q1 (qualitative)</span></th><th><span class="lang-ko">판정</span><span class="lang-en">Assessment</span></th><th><span class="lang-ko">근거 · 설명</span><span class="lang-en">Basis · explanation</span></th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td><span class="lang-ko">공시 품질 고도화 — 재단 지갑 주소 공개 형식 개선, KPI 대시보드↔분기 리포트 연결 강화</span><span class="lang-en">Upgrade disclosure quality — improve the format for publishing the Foundation wallet address; strengthen the link between the KPI dashboard and the quarterly report</span></td><td><span class="lang-ko">🟡 부분</span><span class="lang-en">🟡 Partial</span></td><td><span class="lang-ko">두 요소 중 하나만 이행되었습니다. <strong>지갑 주소 공개 — 달성</strong>: 재단 지갑 주소(Foundation Wallet #1)가 공시 대시보드 Supply Plan 섹션에 상시 공개되어 Etherscan으로 독립 검증 가능합니다. <span class="vb v1">V1</span> <strong>KPI 대시보드↔분기 리포트 연결 강화 — 미달</strong>: 대시보드의 개발 지표와 본 리포트의 추적 범위가 여전히 불일치하며(§A.4), 정합화는 3분기 과제로 남아 있습니다(§13.1 ④-1). 따라서 종합 판정은 <strong>부분</strong>입니다.</span><span class="lang-en">Only one of the two components was delivered. <strong>Wallet address publication — met</strong>: the Foundation wallet address (Foundation Wallet #1) is published on an ongoing basis in the Supply Plan section of the disclosure dashboard and can be independently verified on Etherscan. <span class="vb v1">V1</span> <strong>Strengthening the KPI dashboard ↔ quarterly report link — missed</strong>: the dashboard's development metrics and this report's tracking scope still do not match (§A.4), and reconciliation remains a Q3 task (§13.1 ④-1). The overall assessment is therefore <strong>partial</strong>.</span></td></tr>
+    <tr><td>2</td><td><span class="lang-ko">Algora · AO · BRIDGE 실험 확대 — 관찰 가능한 결정 사례 확대, 감사 추적 가독성 개선</span><span class="lang-en">Expand the Algora · AO · BRIDGE experiments — increase observable decision cases, improve the readability of audit trails</span></td><td><span class="lang-ko">🟡 부분</span><span class="lang-en">🟡 Partial</span></td><td><span class="lang-ko">Algora는 6월 말 공개 서비스 수준 정비(지갑 서명 위임·공개 쓰기 엔드포인트 보호·시뮬레이션 데이터 라벨링)를 완료했고 완결 세션 10건이 공개 대시보드에 집계됩니다. AO는 누적 파이프라인이 프로젝트 66건까지 도달했고, 6월 하순에는 안정화·복원력 강화 작업이 집중되었습니다(§7.4). BRIDGE는 연구 단계를 유지하며 6/30 소개 포스트를 발행했습니다.</span><span class="lang-en">Algora completed a public-service-grade overhaul in late June (wallet-signature delegation, protection of public write endpoints, labelling of simulation data), and 10 completed sessions are counted on its public dashboard. AO's cumulative pipeline reached 66 projects, with late June concentrated on stabilisation and resilience work (§7.4). BRIDGE remained at the research stage and published an introductory post on 6/30.</span></td></tr>
+    <tr><td>3</td><td><span class="lang-ko">AI 활용 정책 확정판 발행 (2월 초안 공개분)</span><span class="lang-en">Publish the final version of the AI usage policy (the February draft was made public)</span></td><td><span class="lang-ko">❌ 미달</span><span class="lang-en">❌ Missed</span></td><td><span class="lang-ko">공개 채널 기준 확정판 발행이 확인되지 않았습니다. §13에서 3분기로 이월합니다.</span><span class="lang-en">No publication of a final version could be confirmed on public channels. Carried over to Q3 in §13.</span></td></tr>
+    <tr><td>4</td><td><span class="lang-ko">디지털 트윈 R&amp;D 컨소시엄 선정 결과 공시</span><span class="lang-en">Disclose the selection result for the digital twin R&amp;D consortium</span></td><td><span class="lang-ko">❌ 미달</span><span class="lang-en">❌ Missed</span></td><td><span class="lang-ko">정부 선정 결과는 <strong>2026-06-25 발표</strong>되었고 재단이 참여한 컨소시엄의 과제가 포함되었으나, 재단은 <strong>분기 내에 후속 공시를 발행하지 않았습니다.</strong> 판정 기준은 둘로 나뉩니다. ① <strong>4/21 공시 방침</strong> — 제6항 5)는 &ldquo;구체적 진행 사항은 공식 채널로 별도 안내된다&rdquo;고만 밝혀 <strong>발행 기한이 없으므로 방침 위반은 아닙니다.</strong> ② <strong>1분기가 제시한 2분기 자체 목표</strong> — 분기 경계로 판정하며, 분기 내 미발행이므로 <strong>미달입니다.</strong> 본 칸의 ❌는 ②에 대한 판정입니다. 해당 공시는 분기 종료 후인 <strong>2026-08-04 발행</strong>되었으며(MOSS-DISC-2026-0804 · §7.1 · §12), 3분기 공시 실적으로 집계됩니다. 예고된 공시 항목의 이행 관리 절차는 §13.1의 <strong>상시 운영 규범</strong>으로 발효합니다(분기 목표가 아니므로 판정 대상은 아니며, 위반 사례가 발생하면 해당 분기 리포트에 기재합니다).</span><span class="lang-en">The government selection result was <strong>announced on 2026-06-25</strong> and included the project of the consortium in which the Foundation participates, but the Foundation <strong>did not publish a follow-up disclosure within the quarter.</strong> Two standards apply. ① <strong>The 4/21 disclosure's own commitment</strong> — §6-5 states only that "specific progress will be announced separately via official channels", setting <strong>no publication deadline, so this is not a breach of that commitment.</strong> ② <strong>The Q2 target set by the Q1 report</strong> — assessed on the quarter boundary; nothing was published within the quarter, so it is <strong>missed.</strong> The ❌ in this cell is the assessment of ②. The disclosure was <strong>published on 2026-08-04</strong>, after quarter-end (MOSS-DISC-2026-0804 · §7.1 · §12), and counts toward Q3 disclosure performance. The procedure for tracking promised disclosure items is in force as a <strong>standing operating rule</strong> in §13.1 (not a quarterly target and so not assessed; any breach is recorded in that quarter's report).</span></td></tr>
+    <tr><td>5</td><td><span class="lang-ko">커뮤니티·OSS 정량 지표(외부 기여자·PR·이슈 해결 시간)의 MossDigest 편입</span><span class="lang-en">Bring community/OSS quantitative metrics (external contributors, PRs, issue resolution time) into MossDigest</span></td><td><span class="lang-ko">❌ 미편입</span><span class="lang-en">❌ Not incorporated</span></td><td><span class="lang-ko">2분기 중 집계 파이프라인 편입 이력이 확인되지 않았습니다(<code>moss_digest</code> 저장소 분기 중 변경 0건). 3분기에는 <strong>자동 집계 파이프라인 구축을 보류</strong>합니다 — 2분기 외부 기여자 PR이 1건으로 확인되어 해당 규모의 지표를 위한 파이프라인은 실익이 없다고 판단했습니다. 다만 <strong>공개 PR 총수 · 고유 작성자 수 · 조직 외부 기여자 PR 수는 수동 집계해 설명 지표로 계속 공시</strong>합니다(§8.3 · §13.1).</span><span class="lang-en">No record of the aggregation pipeline being brought in during Q2 could be confirmed (<code>moss_digest</code> repository: 0 changes during the quarter). For Q3, <strong>building the automated aggregation pipeline is deferred</strong> — external contributor PRs in Q2 were measured at 1, so a pipeline for a metric of that size serves no practical purpose. Total public PRs, distinct authors and PRs from contributors outside the organisation will, however, <strong>continue to be counted manually and disclosed as descriptive indicators</strong> (§8.3 · §13.1).</span></td></tr>
+  </tbody>
+</table>
+
+<table>
+  <thead><tr><th><span class="lang-ko">지표 (정량)</span><span class="lang-en">Indicator (quantitative)</span></th><th><span class="lang-ko">Q1 실적</span><span class="lang-en">Q1 actual</span></th><th><span class="lang-ko">Q2 목표</span><span class="lang-en">Q2 target</span></th><th><span class="lang-ko">Q2 실적</span><span class="lang-en">Q2 actual</span></th><th><span class="lang-ko">판정</span><span class="lang-en">Assessment</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">공식 공시 — 발행 건수</span><span class="lang-en">Official disclosures — number published</span></td><td>1</td><td><span class="lang-ko">이슈 발생 시 즉시</span><span class="lang-en">Immediately upon an issue arising</span></td><td><strong>2</strong></td><td>✅</td></tr>
+    <tr><td><span class="lang-ko">공식 공시 — 트리거 대비 적시성</span><span class="lang-en">Official disclosures — timeliness against triggers</span></td><td><span class="muted"><span class="lang-ko">집계 전</span><span class="lang-en">not yet counted</span></span></td><td><span class="lang-ko">발생 사건의 분기 내 이행</span><span class="lang-en">Events arising in the quarter disclosed within the quarter</span></td><td><span class="lang-ko">2건 중 1건 미이행</span><span class="lang-en">1 of 2 not fulfilled</span></td><td>🟡</td></tr>
+    <tr><td><span class="lang-ko">Medium 블로그 포스트</span><span class="lang-en">Medium blog posts</span></td><td>5</td><td><span class="lang-ko">≥ 6 (KO/EN 페어 ≥ 4)</span><span class="lang-en">≥ 6 (KO/EN pairs ≥ 4)</span></td><td><strong>19</strong> <span class="lang-ko">(페어 7)</span><span class="lang-en">(7 pairs)</span></td><td><span class="lang-ko">✅ 초과</span><span class="lang-en">✅ Exceeded</span></td></tr>
+    <tr><td><span class="lang-ko">공개 커밋 (MosslandOpenDevs 등 공개 저장소)</span><span class="lang-en">Public commits (MosslandOpenDevs and other public repositories)</span></td><td>448</td><td>≥ 500</td><td><strong>261</strong> <span class="muted"><span class="lang-ko">(Q1 동일 범위·전 브랜치 기준 · 신규 공시 기준 259)</span><span class="lang-en">(same scope as Q1, all branches · 259 on the new disclosure basis)</span></span></td><td><span class="lang-ko">❌ 미달</span><span class="lang-en">❌ Missed</span></td></tr>
+    <tr><td><span class="lang-ko">관찰 가능한 에이전트 결정 사례</span><span class="lang-en">Observable agent decision cases</span></td><td><span class="lang-ko">집계 전</span><span class="lang-en">Not yet counted</span></td><td>≥ 10</td><td><span class="lang-ko">판정 유보</span><span class="lang-en">Assessment deferred</span></td><td>🟡</td></tr>
+  </tbody>
+</table>
+
+<div class="callout">
+  <div class="callout-title"><span class="lang-ko">공개 커밋 미달에 대한 설명</span><span class="lang-en">Note on the public-commit shortfall</span></div>
+  <p class="lang-ko">공개 커밋은 신규 공시 기준(기본 브랜치) 259건으로 목표(≥500)에 미달했습니다. Q1 목표가 &ldquo;브랜치 무관&rdquo; 기준이고 259는 기본 브랜치 기준이므로, <strong>Q1과 동일한 범위(MosslandOpenDevs 공개 저장소)·동일한 브랜치 규칙(전 브랜치)으로 재집계했습니다 — 결과는 261건</strong>으로 목표에 약 48% 미달합니다. 따라서 본 판정은 추정이 아니라 <strong>동일 기준 재집계에 근거한 확정 판정</strong>입니다. 재집계는 저자일(author date) 기준 UTC 2026-04-01~07-01, 병합 커밋 포함, SHA 중복 제거로 수행했습니다(절차는 §A.3). 참고로 현행 공시 범위(3개 네임스페이스)의 기본 브랜치 집계가 259건이고, 전 브랜치로 넓히면 273건입니다. <span class="vb v1">V1</span> 확인되는 사실은 두 가지입니다 — 기존 공개 커밋 지표가 감소했고, 신규 확장 집계에서는 활동이 비공개 저장소(디지털 트윈 1,086커밋, Passport·Agora 등 운영 서비스)에 집중된 것으로 나타났습니다. 집계 기준이 달라 전체 활동의 증감은 판정하지 않습니다. 신규 기준의 2분기 집계치는 1,945건(비-컨소시엄 워크스트림 859 · 컨소시엄 기술축 연계 1,086)입니다. <strong>Q1의 448건은 조직 범위·공개성·브랜치 규칙이 모두 달라 직접적인 증감 비교가 성립하지 않으므로, 본 리포트는 배수·증감률을 제시하지 않습니다.</strong> 비교 가능한 추세는 동일 기준이 유지되는 Q2→Q3부터 제공합니다. 이에 따라 이번 분기부터 대표 지표를 <strong>총 커밋(공개·비공개 분리 표기)</strong>으로 전환하고, 수치별 검증 가능성 등급(V1·V2·V3)을 도입합니다. 정의 변경의 상세는 §6.1, 등급 체계는 §6.6·§A를 참조하십시오.</p><p class="lang-en">Public commits totalled 259 on the new disclosure basis (default branch) against a target of ≥ 500. Because the Q1 target was set on a "branch-agnostic" basis while 259 is a default-branch figure, <strong>the count was redone on the same scope as Q1 (MosslandOpenDevs public repositories) and the same branch rule (all branches) — the result is 261</strong>, about 48% short of the target. This assessment therefore rests on a same-basis recount rather than on an estimate. The recount used author date, UTC 2026-04-01 to 07-01, merge commits included, deduplicated by SHA (procedure in §A.3). For reference, the current disclosure scope (three namespaces) gives 259 on the default branch and 273 across all branches. <span class="vb v1">V1</span> Two things are established: the legacy public-commit metric declined, and under the newly widened count the activity is concentrated in private repositories (the digital twin's 1,086 commits, and operational services such as Passport and Agora). Because the counting bases differ, no judgement is made on whether overall activity rose or fell. The Q2 figure on the new basis is 1,945 (non-consortium workstream 859 · aligned with the consortium track 1,086). <strong>Q1's 448 differs in organisational scope, public/private coverage and branch rule alike, so no direct increase/decrease comparison holds, and this report presents no multiples or growth rates.</strong> Comparable trends will be provided from Q2→Q3, where the basis stays constant. Accordingly, from this quarter the headline indicator becomes <strong>total commits (public and private shown separately)</strong>, and a verifiability tier (V1 · V2 · V3) is assigned to figures. See §6.1 for the definition changes and §6.6 · §A for the tier system.</p>
+  <p class="lang-ko">"관찰 가능한 에이전트 결정 사례" 항목은 Q1에 집계 정의가 고정되지 않은 채 목표만 제시되어, 이번 분기에는 판정을 유보합니다. 참고 관측치(2026-08-03 관측)는 Algora 완결 세션 10건 · AO 누적 완성 프로젝트 66건이며, §13에서 정의를 고정한 뒤 3분기부터 판정합니다.</p><p class="lang-en">The "observable agent decision cases" item was set as a target in Q1 without a fixed counting definition, so assessment is deferred this quarter. Reference observations (as of 2026-08-03) are 10 completed Algora sessions and 66 cumulative completed AO projects; the definition will be fixed in §13 and assessment will resume from Q3.</p>
+</div>
+
+<h4><span class="lang-ko">분기 아이덴티티</span><span class="lang-en">Quarter Identity</span></h4>
+<p class="lang-ko"><em>"Reality Enters the Loop."</em> 1분기 리포트의 표지는 REALITY → MINING → CONSENSUS → DECISION → OUTCOME 루프를 그렸습니다. 2분기는 그 첫 번째 칸이 실제로 켜진 분기입니다. 실제 건물의 CCTV·IoT·재실 신호가 트윈으로 들어오기 시작했고(§7.1), 실험 서비스들이 실제 주소를 갖게 되었으며(§5), 홀더의 자가지갑 참여가 서명으로 검증되기 시작했습니다(§7.2). 루프의 나머지 칸(합의·결정·실행)은 여전히 실험 단계이며, 고위험 행동은 사람의 승인 없이 실행되지 않습니다(§3.4).</p><p class="lang-en"><em>"Reality Enters the Loop."</em> The cover of the Q1 report drew a REALITY → MINING → CONSENSUS → DECISION → OUTCOME loop. Q2 is the quarter in which the first of those cells actually lit up. CCTV, IoT and occupancy signals from a real building began flowing into the twin (§7.1), the experimental services acquired real addresses (§5), and holders' self-custody participation began to be verified by signature (§7.2). The remaining cells of the loop (consensus, decision, execution) are still experimental, and high-risk actions are not executed without human approval (§3.4).</p>
+
+<h4><span class="lang-ko">본 리포트의 독자</span><span class="lang-en">Intended Readers</span></h4>
+<p class="lang-ko">MOC 보유자, 상장 거래소·규제 관련 이해관계자, 오픈소스 기여자, 그리고 모스랜드의 방향에 관심 있는 모든 분을 대상으로 합니다. 정량 수치는 §A의 방법론에 따라 집계되었으며, 외부에서 재현 가능한 항목에는 V1 배지를 붙였습니다.</p><p class="lang-en">This report is addressed to MOC holders, exchange and regulatory stakeholders, open-source contributors, and anyone following Mossland's direction. Quantitative figures are compiled under the methodology in §A, and items that can be reproduced externally carry a V1 badge.</p>
+
+<!-- ================= §2 ================= -->
+<h2 class="section" id="s2"><span class="num">§2</span><span class="lang-ko">토큰 공시 (MOC)</span><span class="lang-en">Token Disclosure (MOC)</span></h2>
+
+<p class="lang-ko">모스코인(MOC)은 한국 원화 거래소에 상장된 ERC-20 토큰으로, 모스랜드 생태계에서 사용됩니다(용도는 §2.6). 본 절은 토큰 관련 주요 공시 항목을 정리합니다. 1분기와 달리 2분기에는 <strong>유통계획상 월말 상한과 공개 보고·추정 유통량이 각각 2,000,000 MOC 증가</strong>했습니다(§2.7). 실제 온체인 전환의 집행 여부와 시점은 본 리포트에서 산출하지 않았습니다(§A.2).</p><p class="lang-en">MossCoin (MOC) is an ERC-20 token listed on Korean won markets and used within the Mossland ecosystem (uses are set out in §2.6). This section summarises the principal token disclosure items. Unlike Q1, in Q2 <strong>both the month-end ceiling under the supply plan and the publicly reported/estimated circulating supply rose by 2,000,000 MOC</strong> (§2.7). Whether an on-chain conversion was actually executed, and when, is not computed in this report (§A.2).</p>
+
+<h3 id="s2.1">2.1 <span class="lang-ko">토큰 기본 정보</span><span class="lang-en">Token Fundamentals</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">항목</span><span class="lang-en">Item</span></th><th><span class="lang-ko">내용</span><span class="lang-en">Detail</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">토큰명 · 심볼</span><span class="lang-en">Token name · symbol</span></td><td>Mosscoin · MOC</td></tr>
+    <tr><td><span class="lang-ko">토큰 표준</span><span class="lang-en">Token standard</span></td><td>ERC-20 (Ethereum Mainnet)</td></tr>
+    <tr><td><span class="lang-ko">컨트랙트 주소</span><span class="lang-en">Contract address</span></td><td><span class="mono">0x8bbfe65e31b348cd823c62e02ad8c19a84dd0dab</span> · <a href="https://etherscan.io/token/0x8bbfe65e31b348cd823c62e02ad8c19a84dd0dab" target="_blank" rel="noopener"><span class="lang-ko">Etherscan 검증</span><span class="lang-en">Verify on Etherscan</span></a></td></tr>
+    <tr><td><span class="lang-ko">최대 발행량</span><span class="lang-en">Maximum supply</span></td><td>500,000,000 MOC</td></tr>
+    <tr><td><span class="lang-ko">분기말 유통량<sup>1</sup></span><span class="lang-en">Circulating supply at quarter-end<sup>1</sup></span></td><td><strong>448,489,688 MOC (89.70%)</strong> <span class="vb v2">V2</span></td></tr>
+    <tr><td><span class="lang-ko">상장 거래소 (원화 마켓)</span><span class="lang-en">Listed exchanges (KRW markets)</span></td><td>Upbit · Bithumb · Coinone · GOPAX</td></tr>
+    <tr><td><span class="lang-ko">거버넌스 플랫폼</span><span class="lang-en">Governance platform</span></td><td><a href="https://agora.moss.land" target="_blank" rel="noopener">agora.moss.land</a> — <span class="lang-ko">토큰 가중 투표 (1 MOC = 1 표) · 지갑 서명 기반(트랜잭션·가스비 없음)</span><span class="lang-en">token-weighted voting (1 MOC = 1 vote) · signature-based, no transaction or gas</span></td></tr>
+    <tr><td><span class="lang-ko">공시 저장소</span><span class="lang-en">Disclosure repository</span></td><td><a href="https://github.com/mossland/Disclosure-and-Materials" target="_blank" rel="noopener">github.com/mossland/Disclosure-and-Materials</a></td></tr>
+    <tr><td><span class="lang-ko">실시간 공시 대시보드</span><span class="lang-en">Live disclosure dashboard</span></td><td><a href="https://disclosure.moss.land" target="_blank" rel="noopener">disclosure.moss.land</a></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><sup>1</sup> 분기말(2026-06-30) 유통량은 CoinGecko 분기말 시점 데이터의 시가총액÷가격 역산으로 도출한 448,489,688이며, 현재(2026-08-01) 3개 출처(CoinGecko · CoinMarketCap · 재단 집계)가 일치하는 449,489,688에서 8월 유통 전환분 +1,000,000을 소급 차감한 값과 정합합니다. 또한 <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/Total%20Number%20of%20Tokens%20in%20Circulation/2025-01-09%2BMOC%2B(Token%2BSupply%2BSchedule).pdf" target="_blank" rel="noopener">2025-01-09 공시 「MOC 유통계획」</a>의 월말 기준 수치(6/30/26 448,489,688 · 8/31/26 449,489,688)와도 일치합니다. 이 값은 CoinGecko 보고 기준의 <strong>추정치</strong>이며, 시가총액이 공급량을 이용해 산출되는 점에서 독립적인 온체인 유통량 검증이 아닙니다(등급 V2). 온체인 기준 유통량 산출(기준 블록·비유통 지갑 잔액·산식 공개)은 3분기 과제입니다(§13.1).</p><p class="small lang-en"><sup>1</sup> The quarter-end (2026-06-30) circulating supply of 448,489,688 is derived by back-calculating CoinGecko quarter-end market cap ÷ price, and is consistent with the current (2026-08-01) figure of 449,489,688 — on which three sources agree (CoinGecko · CoinMarketCap · the Foundation's own count) — less the August conversion of +1,000,000 applied retrospectively. It also matches the month-end figures in the <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/Total%20Number%20of%20Tokens%20in%20Circulation/2025-01-09%2BMOC%2B(Token%2BSupply%2BSchedule).pdf" target="_blank" rel="noopener">2025-01-09 disclosure “MOC Supply Plan”</a> (6/30/26 448,489,688 · 8/31/26 449,489,688). This value is an <strong>estimate</strong> on CoinGecko's reporting basis and, because market cap is itself computed from supply, is not independent on-chain verification of circulating supply (tier V2). Computing circulating supply on an on-chain basis (publishing the reference block, non-circulating wallet balances and the formula) is a Q3 task (§13.1).</p>
+
+<h3 id="s2.2">2.2 <span class="lang-ko">네트워크 마이그레이션 이력</span><span class="lang-en">Network Migration History</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">시점</span><span class="lang-en">Date</span></th><th><span class="lang-ko">이벤트</span><span class="lang-en">Event</span></th><th><span class="lang-ko">근거</span><span class="lang-en">Basis</span></th></tr></thead>
+  <tbody>
+    <tr><td>~ 2024</td><td><span class="lang-ko">Luniverse 체인에서 MOC 운영</span><span class="lang-en">MOC operated on the Luniverse chain</span></td><td>—</td></tr>
+    <tr><td>2025-08</td><td><span class="lang-ko">Ethereum Mainnet 이전안 DAO 투표 승인</span><span class="lang-en">DAO vote approved the migration to Ethereum Mainnet</span></td><td><a href="https://agora.moss.land" target="_blank" rel="noopener">agora.moss.land</a></td></tr>
+    <tr><td>2025-11</td><td><span class="lang-ko">LMT → ERC-20 네트워크 스왑 실행</span><span class="lang-en">LMT → ERC-20 network swap executed</span></td><td>Medium</td></tr>
+    <tr><td>2025-12</td><td><span class="lang-ko">Luniverse MOC 소각 완료 공시</span><span class="lang-en">Disclosure of the completed Luniverse MOC burn</span></td><td>Medium</td></tr>
+    <tr><td>2026 Q1–Q2</td><td><span class="lang-ko"><strong>네트워크 관련 이벤트 없음.</strong> 단일 ERC-20 체제 유지.</span><span class="lang-en"><strong>No network-related events.</strong> The single ERC-20 arrangement was maintained.</span></td><td>—</td></tr>
+  </tbody>
+</table>
+
+<h3 id="s2.3">2.3 <span class="lang-ko">분기말 주요 지표</span><span class="lang-en">Quarter-End Market Metrics</span></h3>
+<div class="kpi">
+  <div class="cell"><div class="label">Market Cap (KRW)</div><div class="value">₩11.57B</div><div class="unit">2026-06-30 · CoinGecko <span class="vb v1">V1</span></div></div>
+  <div class="cell"><div class="label">Market Cap (USD)</div><div class="value">$7.46M</div><div class="unit"><span class="lang-ko">동일 시점</span><span class="lang-en">Same point in time</span></div></div>
+  <div class="cell"><div class="label">MOC Price</div><div class="value">₩25.8</div><div class="unit">2026-06-30 · ≈ $0.0166</div></div>
+  <div class="cell"><div class="label">Circulating / Max</div><div class="value">89.70%</div><div class="unit"><span class="lang-ko">유통량 / 최대발행량</span><span class="lang-en">Circulating / maximum supply</span></div></div>
+</div>
+<p class="lang-ko">이번 분기부터 시장 지표의 기준 시점을 <strong>분기말(6/30)</strong>로 고정합니다. 1분기 리포트는 발행일(4/21) 시점 수치(₩18.8B)를 사용했으며, 동일 관행으로는 발행 시점에 따라 수치가 표류해 분기간 비교가 어렵기 때문입니다. 분기말 기준 시가총액은 <strong>직전 리포트가 공시한 발행일(4/21) 시점 값 대비</strong> 약 −38.5%이며(기준 시점이 달라 QoQ 비교는 아닙니다 — §2.8), 52주 가격 범위는 ₩104 ~ ₩24.3(Upbit 기준)으로 분기말 가격은 저점 부근입니다. 가격·시세는 외부 요인에 따라 변동하며, 실시간 지표는 <a href="https://disclosure.moss.land" target="_blank" rel="noopener">공시 대시보드</a>에서 상시 확인 가능합니다.</p><p class="lang-en">From this quarter the reference point for market indicators is fixed at <strong>quarter-end (6/30)</strong>. The Q1 report used the figure as of its publication date (4/21, ₩18.8B); under that practice the numbers drift with the publication date and quarters become hard to compare. On a quarter-end basis, market capitalisation is about −38.5% <strong>against the value the previous report disclosed as of its publication date (4/21)</strong> — the reference points differ, so this is not a quarter-over-quarter comparison (§2.8). The 52-week price range is ₩104 to ₩24.3 (Upbit), placing the quarter-end price near the low. Prices move with external factors, and live indicators are available at all times on the <a href="https://disclosure.moss.land" target="_blank" rel="noopener">disclosure dashboard</a>.</p>
+
+<figure class="viz" aria-label="Market cap QoQ and 52-week price range">
+  <div class="vizscroll"><svg viewBox="0 0 900 238" role="img" aria-label="Market cap QoQ and 52-week price range">
+<text x="40" y="28" font-family="Georgia,serif" font-size="13" fill="#111418" font-weight="bold">시가총액 (KRW)</text>
+<rect x="60" y="52.0" width="92" height="110.0" fill="#cecac1"/>
+<text x="106" y="44.0" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="11" fill="#111418" font-weight="bold">₩18.8B</text>
+<text x="106" y="178" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068">Q1 · 4/21</text>
+<rect x="210" y="94.3" width="92" height="67.7" fill="#15665c"/>
+<text x="256" y="86.3" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="11" fill="#111418" font-weight="bold">₩11.57B</text>
+<text x="256" y="178" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068">Q2 · 6/30</text>
+<line x1="60" y1="162" x2="302" y2="162" stroke="#cecac1"/>
+<text x="181" y="200" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="12" fill="#8a1e1e" font-weight="bold">직전 리포트 대비 약 −38.5%</text>
+<text x="181" y="215" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9" fill="#5b6068">기준 시점 변경(발행일→분기말) 반영 — §2.3</text>
+<line x1="400" y1="24" x2="400" y2="186" stroke="#e4e2dc"/>
+<text x="440" y="28" font-family="Georgia,serif" font-size="13" fill="#111418" font-weight="bold">52주 가격 범위 (Upbit 기준)</text>
+<rect x="470" y="83" width="360" height="18" fill="#e4e2dc" rx="9"/>
+<rect x="470" y="83" width="6.8" height="18" fill="#e5efec" rx="9"/>
+<circle cx="476.8" cy="92" r="6.5" fill="#15665c" stroke="#fff" stroke-width="2"/>
+<g font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068">
+<text x="470" y="120" text-anchor="start">52주 저점 ₩24.3</text>
+<text x="830" y="120" text-anchor="end">52주 고점 ₩104</text></g>
+<text x="476.8" y="74" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="11" fill="#0d4a43" font-weight="bold">분기말 ₩25.8</text>
+<text x="650" y="154" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9" fill="#5b6068">분기말 가격은 52주 저점 부근 (저점 대비 +6.2%)</text>
+</svg></div>
+  <figcaption>Figure 2.3 · <span class="lang-ko">분기말 시장 지표. 시가총액은 기준 시점을 발행일에서 분기말로 고정한 뒤의 비교이며(§2.3), 가격은 52주 범위 안에서 분기말 위치를 표시했습니다. 시세는 외부 요인에 따라 변동합니다.</span><span class="lang-en">Quarter-end market indicators. Market capitalisation is compared after fixing the reference point from the publication date to quarter-end (§2.3), and the price is shown as its quarter-end position within the 52-week range. Prices move with external factors.</span></figcaption>
+</figure>
+
+<h3 id="s2.4">2.4 <span class="lang-ko">상장 거래소 현황</span><span class="lang-en">Exchange Listing Status</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">거래소</span><span class="lang-en">Exchange</span></th><th><span class="lang-ko">마켓</span><span class="lang-en">Market</span></th><th><span class="lang-ko">비고</span><span class="lang-en">Notes</span></th></tr></thead>
+  <tbody>
+    <tr><td>Upbit</td><td>KRW</td><td><span class="lang-ko">원화 마켓 상장 유지</span><span class="lang-en">KRW market listing maintained</span></td></tr>
+    <tr><td>Bithumb</td><td>KRW</td><td><span class="lang-ko">원화 마켓 상장 유지</span><span class="lang-en">KRW market listing maintained</span></td></tr>
+    <tr><td>Coinone</td><td>KRW</td><td><span class="lang-ko">2025-08 신규 상장 이후 유지</span><span class="lang-en">Maintained since the new listing in 2025-08</span></td></tr>
+    <tr><td>GOPAX</td><td>KRW</td><td><span class="lang-ko">2025-11 신규 상장 이후 유지</span><span class="lang-en">Maintained since the new listing in 2025-11</span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko">2분기 중 추가 상장·상장폐지·유의종목 지정 등의 변동은 없었습니다. 본 리포트는 개별 거래소의 재량적 조치 여부에 대한 독립 검증을 수행하지 않으며, 거래소 공지와 재단 공식 공시 채널을 상시 참조해 주시기 바랍니다.</p><p class="small lang-en">There were no additional listings, delistings or designations as a caution issue during Q2. This report does not independently verify discretionary actions by individual exchanges; please refer to exchange notices and the Foundation's official disclosure channels on an ongoing basis.</p>
+
+<h3 id="s2.5">2.5 <span class="lang-ko">재단 지갑 주소 공개 · 보유 검증 경로</span><span class="lang-en">Foundation Wallet Disclosure</span></h3>
+<p class="lang-ko">재단은 일정량의 MOC를 보유하며, 이는 사업비 집행(개발·마케팅·인건비 등)과 커뮤니티 프로그램 재원으로 활용될 수 있습니다. 1분기 리포트에서 목표로 제시한 <strong>재단 보유 지갑 주소 공개</strong>가 이행되어, Foundation Wallet #1(<span class="mono">0xcda8f4d40dbeaecf7ee7221f9e9b35d565ca2ad2</span>)과 비유통 물량 보관 지갑 목록이 공시 대시보드 Supply Plan 섹션에 상시 공개되어 있습니다. 누구나 Etherscan 등 공개 블록체인 익스플로러로 실시간 잔고·거래 내역을 독립 검증할 수 있습니다. <span class="vb v1">V1</span></p><p class="lang-en">The Foundation holds a quantity of MOC that may be used for operating expenditure (development, marketing, personnel and so on) and as a source of funding for community programmes. The <strong>publication of the Foundation's holding wallet address</strong>, set as a target in the Q1 report, has been delivered: Foundation Wallet #1 (<span class="mono">0xcda8f4d40dbeaecf7ee7221f9e9b35d565ca2ad2</span>) and the list of wallets holding non-circulating supply are published on an ongoing basis in the Supply Plan section of the disclosure dashboard. Anyone can independently verify balances and transaction history in real time using Etherscan or another public block explorer. <span class="vb v1">V1</span></p>
+
+<h3 id="s2.6">2.6 <span class="lang-ko">현재 MOC 유틸리티</span><span class="lang-en">Current MOC Utilities</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">유틸리티</span><span class="lang-en">Utility</span></th><th><span class="lang-ko">설명</span><span class="lang-en">Description</span></th><th><span class="lang-ko">상태</span><span class="lang-en">Status</span></th><th><span class="lang-ko">검증 앵커</span><span class="lang-en">Verification anchor</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">거버넌스 투표</span><span class="lang-en">Governance voting</span></td><td><span class="lang-ko">Agora에서 1 MOC = 1 표 토큰 가중 투표. MIP 제출·토론·의결. 투표는 지갑 서명으로 이루어지며 트랜잭션·가스비가 발생하지 않습니다.</span><span class="lang-en">Token-weighted voting on Agora at 1 MOC = 1 vote: MIP submission, discussion and resolution. Votes are cast by wallet signature, with no transaction and no gas fee.</span></td><td><span class="lang-ko">운영</span><span class="lang-en">Operations</span></td><td><a href="https://agora.moss.land" target="_blank" rel="noopener">agora.moss.land</a> · §9.3</td></tr>
+    <tr><td><span class="lang-ko">참여 자격 · 활동 증명 <strong>(신규)</strong></span><span class="lang-en">Eligibility · proof of participation <strong>(new)</strong></span></td><td><span class="lang-ko">Passport에서 자가지갑 MOC 보유(체크인 시점 100 MOC 기준)를 서명으로 인증하고, 월간 체크인·시그널 투표·거버넌스 위임의 자격 기반으로 사용. 트랜잭션이 아닌 서명 기반으로 가스비가 들지 않습니다.</span><span class="lang-en">Passport verifies self-custody MOC holdings by signature (100 MOC as at the moment of check-in) and uses this as the eligibility basis for monthly check-ins, signal votes and governance delegation. It is signature-based rather than transaction-based, so no gas is incurred.</span></td><td><span class="lang-ko">오픈베타 (6/30~)</span><span class="lang-en">Open beta (from 6/30)</span></td><td><a href="https://passport.moss.land" target="_blank" rel="noopener">passport.moss.land</a> · §7.2</td></tr>
+    <tr><td><span class="lang-ko">생태계 서비스 보유자 구분 <strong>(신규)</strong></span><span class="lang-en">Holder recognition in ecosystem services <strong>(new)</strong></span></td><td><span class="lang-ko">Mossverse가 Passport 연결 결과로 회원·MOC 보유자를 구분해 인식합니다. 생태계 서비스가 Passport를 인증·자격 계층으로 사용하는 첫 사례입니다.</span><span class="lang-en">Mossverse distinguishes members from MOC holders based on the result of a Passport connection. This is the first case of an ecosystem service using Passport as its authentication and eligibility layer.</span></td><td><span class="lang-ko">운영 (6/24~)</span><span class="lang-en">Operating (from 6/24)</span></td><td><a href="https://wa.moss.land" target="_blank" rel="noopener">wa.moss.land</a> · §7.6</td></tr>
+    <tr><td><span class="lang-ko">커뮤니티 보상</span><span class="lang-en">Community rewards</span></td><td><span class="lang-ko">이벤트·해커톤·오픈소스 기여자 지원 프로그램의 보상 재원. 제도는 상시 유지되나 2분기 중 신규 진행·지급 실적은 없었습니다.</span><span class="lang-en">A funding source for events, hackathons and the open-source contributor support programme. The scheme is maintained on an ongoing basis, but there were no new awards or payouts during Q2.</span></td><td><span class="lang-ko">운영 · 분기 중 집행 없음</span><span class="lang-en">Operating · no disbursement during the quarter</span></td><td>§8.3</td></tr>
+    <tr><td><span class="lang-ko">가상 부동산 · 아이템 거래</span><span class="lang-en">Virtual real estate · item trading</span></td><td><span class="lang-ko">구 메타버스 서비스 기준의 유틸리티입니다. 현행 Mossverse에서는 제공되지 않습니다.</span><span class="lang-en">A utility defined for the former metaverse service. It is not offered in the current Mossverse.</span></td><td><span class="lang-ko">현행 미제공</span><span class="lang-en">Not currently offered</span></td><td>§7.6</td></tr>
+    <tr><td><span class="lang-ko">NFT · 디지털 자산 결제</span><span class="lang-en">NFT · digital asset payments</span></td><td><span class="lang-ko">과거 유틸리티 정의에 포함되었으나, 현재 MOC를 결제 수단으로 사용하는 생태계 서비스는 없습니다.</span><span class="lang-en">Included in earlier utility definitions, but no ecosystem service currently accepts MOC as a means of payment.</span></td><td><span class="lang-ko">미운영</span><span class="lang-en">Not operating</span></td><td>—</td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko">본 표는 유틸리티의 <strong>설계상 존재 여부가 아니라 발행 시점의 실제 가동 상태</strong>를 기재합니다. 검증 앵커(공개 서비스 URL 또는 본문 섹션)가 없는 항목은 "운영"으로 표기하지 않습니다. 이번 분기부터 앵커 열을 신설하고, 앵커 없이 "운영"으로 표기되어 있던 항목 2건(가상 부동산·아이템 거래, NFT·디지털 자산 결제)의 상태를 정정했습니다. <span class="vb v2">V2</span></p><p class="small lang-en">This table records <strong>the actual operating status at the time of publication, not whether a utility exists by design</strong>. Any item without a verification anchor (a public service URL or a section of this report) is not marked "operating". The anchor column is new this quarter, and the status of two items that had been marked "operating" without an anchor (virtual real-estate and item trading; NFT and digital asset payments) has been corrected. <span class="vb v2">V2</span></p>
+
+<h3 id="s2.7">2.7 <span class="lang-ko">분기 중 토큰 이벤트</span><span class="lang-en">Quarterly Token Events</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">카테고리</span><span class="lang-en">Category</span></th><th><span class="lang-ko">2026 Q2 이벤트</span><span class="lang-en">2026 Q2 event</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">발행 · 소각</span><span class="lang-en">Issuance · burn</span></td><td><span class="lang-ko">없음 (최대 발행량 500,000,000 불변)</span><span class="lang-en">None (maximum supply of 500,000,000 unchanged)</span></td></tr>
+    <tr><td><span class="lang-ko"><strong>유통량 전환</strong></span><span class="lang-en"><strong>Circulating supply change</strong></span></td><td><span class="lang-ko"><strong>유통계획상 월말 상한 +2,000,000 MOC</strong> (5월 +1,000,000 · 6월 +1,000,000) — 두 건 모두 2025-01-09 공시에 사전 공개된 일정입니다<sup>2</sup> <span class="vb v1">V1</span><br><strong>공개 보고·추정 유통량</strong>도 동일하게 +2,000,000 <span class="vb v2">V2</span><br><strong>온체인 기준 실현 전환</strong> — <strong>본 리포트 미산출</strong>. 재단 보유분이 실제로 언제 유통 상태로 넘어갔는지는 확정하지 않습니다(§A.2 · §A.4)</span><span class="lang-en"><strong>Month-end ceiling under the supply plan: +2,000,000 MOC</strong> (May +1,000,000 · June +1,000,000) — both were published in advance in the 2025-01-09 filing<sup>2</sup> <span class="vb v1">V1</span><br><strong>Publicly reported/estimated circulating supply</strong> rose by the same +2,000,000 <span class="vb v2">V2</span><br><strong>On-chain realised conversion</strong> — <strong>not computed in this report</strong>. When the Foundation's holdings actually moved into circulation is not established (§A.2 · §A.4)</span></td></tr>
+    <tr><td><span class="lang-ko">락업 해제</span><span class="lang-en">Lock-up release</span></td><td><span class="lang-ko">해당 없음</span><span class="lang-en">Not applicable</span></td></tr>
+    <tr><td><span class="lang-ko">팀·파트너 분배</span><span class="lang-en">Team · partner distribution</span></td><td><span class="lang-ko">없음</span><span class="lang-en">None</span></td></tr>
+    <tr><td><span class="lang-ko">네트워크 이전</span><span class="lang-en">Network migration</span></td><td><span class="lang-ko">없음 (2025 Q4 완료)</span><span class="lang-en">None (completed in 2025 Q4)</span></td></tr>
+    <tr><td><span class="lang-ko">거래소 상장·상장폐지</span><span class="lang-en">Exchange listings · delistings</span></td><td><span class="lang-ko">없음 — 기존 4개 원화 마켓 유지</span><span class="lang-en">None — the existing four KRW markets were maintained</span></td></tr>
+    <tr><td><span class="lang-ko">스마트 컨트랙트 업그레이드</span><span class="lang-en">Smart contract upgrade</span></td><td><span class="lang-ko">없음</span><span class="lang-en">None</span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><sup>2</sup> 증가분이 배정된 월은 <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/Total%20Number%20of%20Tokens%20in%20Circulation/2025-01-09%2BMOC%2B(Token%2BSupply%2BSchedule).pdf" target="_blank" rel="noopener">2025-01-09 공시 「MOC 유통계획」</a>의 월말 기준 수치로 확정됩니다 — 4/30/26 446,489,688 → 5/31/26 447,489,688 → 6/30/26 448,489,688. 6월분은 공시 대시보드에서도 확인됩니다(서비스 개발·마케팅·운영 목적). <strong>분기 중 새로 결정된 전환은 없습니다.</strong> 유통계획은 월말 기준 <strong>최대 유통 가능 수량</strong>이므로, 유통계획이 확정하는 것은 <strong>각 월말에 허용된 상한</strong>이며, 해당 월에 실제로 온체인 전환이 집행되었다는 사실까지 확정하지는 않습니다. 온체인 기준 실현 유통량은 본 리포트에서 산출하지 않았고, 재단 지갑(§2.5)의 온체인 기록으로 확인할 수 있습니다(§A.2 · §A.4).</p><p class="small lang-en"><sup>2</sup> The months to which the increases are assigned are fixed by the month-end figures in the <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/Total%20Number%20of%20Tokens%20in%20Circulation/2025-01-09%2BMOC%2B(Token%2BSupply%2BSchedule).pdf" target="_blank" rel="noopener">2025-01-09 disclosure “MOC Supply Plan”</a> — 4/30/26 446,489,688 → 5/31/26 447,489,688 → 6/30/26 448,489,688. The June tranche is also visible on the disclosure dashboard (for service development, marketing and operations). <strong>No new conversion was decided during the quarter.</strong> Because the supply plan states a <strong>maximum permitted circulating supply</strong> at each month-end, what it fixes is <strong>the ceiling permitted at that month-end</strong> — not the fact that an on-chain conversion was actually executed in that month. On-chain realised circulating supply is not computed in this report and can be checked against the on-chain record of the Foundation wallets (§2.5) (§A.2 · §A.4).</p>
+<p class="small lang-ko">향후 예정된 유통량 전환은 공시 대시보드에 사전 공개됩니다 — 2026-08 +1,000,000 · 2026-09 +1,000,000 (서비스 개발·마케팅·운영) · 2026-11 +5,000,000 (서비스 개발·마케팅·운영 및 사업 운영) · 2026-12 +1,000,000. 예정 수량·시점은 변경될 수 있으며 변경 시 대시보드에 반영됩니다.</p><p class="small lang-en">Forthcoming circulating-supply conversions are published in advance on the disclosure dashboard — 2026-08 +1,000,000 · 2026-09 +1,000,000 (service development, marketing and operations) · 2026-11 +5,000,000 (service development, marketing and operations, and business operations) · 2026-12 +1,000,000. Scheduled amounts and timing may change, and any change is reflected on the dashboard.</p>
+
+<figure class="viz" aria-label="MOC circulating supply 2026, plan versus observed">
+  <div class="vizscroll"><svg viewBox="0 0 900 300" role="img" aria-label="MOC circulating supply 2026 — plan vs observed">
+<rect x="271" y="40" width="169" height="184" fill="#e5efec" opacity="0.75"/>
+<text x="356" y="34" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#15665c">2026 Q2 (보고 기간) · 계획상 +2,000,000 (5월·6월 각 +1,000,000)</text>
+<g stroke="#e4e2dc" stroke-width="1">
+<line x1="95" y1="219.1" x2="855" y2="219.1"/>
+<line x1="95" y1="180.0" x2="855" y2="180.0"/>
+<line x1="95" y1="140.9" x2="855" y2="140.9"/>
+<line x1="95" y1="101.8" x2="855" y2="101.8"/>
+<line x1="95" y1="62.7" x2="855" y2="62.7"/>
+</g>
+<g font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068" text-anchor="end">
+<text x="87" y="222.1">440M</text>
+<text x="87" y="183.0">444M</text>
+<text x="87" y="143.9">448M</text>
+<text x="87" y="104.8">452M</text>
+<text x="87" y="65.7">456M</text>
+</g>
+<line x1="95" y1="224" x2="855" y2="224" stroke="#cecac1" stroke-width="1"/>
+<g font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068" text-anchor="middle">
+<text x="95.0" y="239">1</text>
+<text x="164.1" y="239">2</text>
+<text x="233.2" y="239">3</text>
+<text x="302.3" y="239">4</text>
+<text x="371.4" y="239">5</text>
+<text x="440.5" y="239">6</text>
+<text x="509.5" y="239">7</text>
+<text x="578.6" y="239">8</text>
+<text x="647.7" y="239">9</text>
+<text x="716.8" y="239">10</text>
+<text x="785.9" y="239">11</text>
+<text x="855.0" y="239">12</text>
+<text x="863" y="239" text-anchor="start">월</text></g>
+<polyline points="95.0,214.3 164.1,214.3 233.2,204.5 302.3,155.7 371.4,145.9 440.5,136.1 509.5,136.1 578.6,126.3 647.7,116.5 716.8,116.5 785.9,67.7 855.0,57.9" fill="none" stroke="#15665c" stroke-width="1.8"/>
+<g fill="#15665c">
+<circle cx="95.0" cy="214.3" r="2.4"/>
+<circle cx="164.1" cy="214.3" r="2.4"/>
+<circle cx="233.2" cy="204.5" r="2.4"/>
+<circle cx="302.3" cy="155.7" r="2.4"/>
+<circle cx="371.4" cy="145.9" r="2.4"/>
+<circle cx="440.5" cy="136.1" r="2.4"/>
+<circle cx="509.5" cy="136.1" r="2.4"/>
+<circle cx="578.6" cy="126.3" r="2.4"/>
+<circle cx="647.7" cy="116.5" r="2.4"/>
+<circle cx="716.8" cy="116.5" r="2.4"/>
+<circle cx="785.9" cy="67.7" r="2.4"/>
+<circle cx="855.0" cy="57.9" r="2.4"/>
+</g>
+<g fill="#8a6500">
+<circle cx="281.5" cy="155.7" r="4" fill="#fff" stroke="#8a6500" stroke-width="1.8"/>
+<circle cx="440.5" cy="136.1" r="4" fill="#fff" stroke="#8a6500" stroke-width="1.8"/>
+<circle cx="511.8" cy="126.3" r="4" fill="#fff" stroke="#8a6500" stroke-width="1.8"/>
+</g>
+<g font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#8a6500">
+<text x="272.5" y="159.7" text-anchor="end">4/21 집계값 446,489,688</text>
+<text x="440.5" y="158.1" text-anchor="middle">6/30 보고·추정값 448,489,688</text>
+<text x="511.8" y="107.3" text-anchor="middle">8/1 집계값 449,489,688</text>
+</g>
+<g font-family="ui-monospace,Menlo,monospace" font-size="10">
+<line x1="95" y1="266" x2="117" y2="266" stroke="#15665c" stroke-width="1.8"/>
+<text x="123" y="269" fill="#5b6068">2025-01-09 공시 유통계획 (월말 기준 최대 유통 가능 수량)</text>
+<circle cx="563" cy="266" r="4" fill="#fff" stroke="#8a6500" stroke-width="1.8"/>
+<text x="573" y="269" fill="#5b6068">공개 보고·집계값</text>
+</g></svg></div>
+  <figcaption>Figure 2.7 · <span class="lang-ko">2026년 MOC 유통량 — 선은 2025-01-09 공시 「MOC 유통계획」의 <strong>월말 기준 최대 유통 가능 수량</strong>이고, 원은 본 리포트의 <strong>공개 보고·집계값</strong>입니다. 2분기 증가분 2건(5월·6월 각 +1,000,000)은 모두 2025년 1월에 공개된 계획에 포함되어 있습니다. <strong>이 그림은 계획과 보고값의 일치를 보여줄 뿐, 각 달에 실제로 온체인 전환이 집행되었음을 증명하지 않습니다</strong>(온체인 실현 유통량은 본 리포트에서 산출하지 않았습니다 — §A.2). 계획이 월말 상한이므로, 월 초에 집행되면 집계값이 해당 월말 수준에 먼저 도달할 수 있습니다(8/1 참조).</span><span class="lang-en">MOC circulating supply through 2026 — the line is the <strong>month-end maximum permitted circulating supply</strong> from the 2025-01-09 "MOC Supply Plan" filing, and the circles are this report's <strong>publicly reported/aggregated figures</strong>. Both Q2 increases (May and June, +1,000,000 each) were already included in the plan published in January 2025. <strong>This chart shows only that plan and reported figures agree; it does not evidence that an on-chain conversion was executed in either month</strong> (on-chain realised circulating supply is not computed in this report — §A.2). Because the plan is a month-end ceiling, an execution early in a month can bring the reported figure to that month-end level ahead of time (see 8/1).</span></figcaption>
+</figure>
+
+<h3 id="s2.8">2.8 <span class="lang-ko">직전 리포트 대비 (기준 시점 상이)</span><span class="lang-en">Change vs. Previous Report</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">지표</span><span class="lang-en">Indicator</span></th><th>2026 Q1 (04-21)</th><th>2026 Q2 (06-30)</th><th><span class="lang-ko">변화<sup>3</sup></span><span class="lang-en">Change<sup>3</sup></span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">유통량 (MOC)</span><span class="lang-en">Circulating supply (MOC)</span></td><td>446,489,688</td><td>448,489,688</td><td>+2,000,000</td></tr>
+    <tr><td><span class="lang-ko">유통 / 최대</span><span class="lang-en">Circulating / maximum</span></td><td>89.30%</td><td>89.70%</td><td>+0.40%p</td></tr>
+    <tr><td><span class="lang-ko">시가총액 (KRW)<sup>3</sup></span><span class="lang-en">Market capitalisation (KRW)<sup>3</sup></span></td><td>₩18.8B (04-21)</td><td>₩11.57B (06-30)</td><td>≈ −38.5%</td></tr>
+    <tr><td><span class="lang-ko">공식 공시</span><span class="lang-en">Official disclosures</span></td><td>1</td><td>2</td><td>+1</td></tr>
+    <tr><td><span class="lang-ko">블로그 포스트</span><span class="lang-en">Blog posts</span></td><td>5</td><td>19</td><td>+14</td></tr>
+    <tr><td><span class="lang-ko">KO/EN 동일일 페어</span><span class="lang-en">Same-day KO/EN pairs</span></td><td><span class="lang-ko">2/3 주제</span><span class="lang-en">2 of 3 topics</span></td><td><span class="lang-ko">7/12 주제</span><span class="lang-en">7 of 12 topics</span></td><td>—</td></tr>
+    <tr><td><span class="lang-ko">공개 커밋 — Q1 비교 기준(전 브랜치)</span><span class="lang-en">Public commits — Q1 comparison basis (all branches)</span></td><td>448</td><td>261</td><td><span class="lang-ko">−187 (약 −41.7%)</span><span class="lang-en">−187 (about −41.7%)</span></td></tr>
+    <tr><td><span class="lang-ko">공개 커밋 — 신규 공시 기준(기본 브랜치)</span><span class="lang-en">Public commits — new disclosure basis (default branch)</span></td><td><span class="muted lang-ko">집계 없음</span><span class="muted lang-en">not counted</span></td><td>259</td><td><span class="muted lang-ko">기준 확립 분기</span><span class="muted lang-en">basis-setting quarter</span></td></tr>
+    <tr><td><span class="lang-ko">총 커밋 (3개 GitHub 네임스페이스 · 비공개 포함)</span><span class="lang-en">Total commits (three GitHub namespaces · private included)</span></td><td><span class="muted"><span class="lang-ko">집계 없음</span><span class="lang-en">not counted</span></span></td><td>1,945</td><td><span class="lang-ko">기준 확립 분기</span><span class="lang-en">Basis-setting quarter</span></td></tr>
+    <tr><td><span class="lang-ko">상장 원화 마켓</span><span class="lang-en">Listed KRW markets</span></td><td>4</td><td>4</td><td>—</td></tr>
+    <tr><td><span class="lang-ko">라이브 도메인 (*.moss.land)</span><span class="lang-en">Live domains (*.moss.land)</span></td><td><span class="muted">~9</span></td><td>18</td><td><span class="lang-ko">약 +9 <span class="muted">(도메인 기준 · 신규 공개 독립 서비스는 8건, §5)</span></span><span class="lang-en">about +9 <span class="muted">(domains; 8 new distinct services were published, §5)</span></span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><sup>3</sup> Q1 수치는 리포트 <strong>발행일(4/21)</strong> 시점, Q2 수치는 <strong>분기말(6/30)</strong> 시점입니다. 기준 시점이 서로 다르므로 <strong>본 표의 변화는 분기 대 분기(QoQ) 비교가 아니며</strong>, &ldquo;직전 리포트가 공시한 값 대비 변화&rdquo;로 읽어야 합니다. §2.3의 기준 시점 변경에 따라 <strong>동일 기준의 QoQ는 Q2→Q3부터</strong> 제공됩니다.</p><p class="small lang-en"><sup>3</sup> The Q1 figures are as at the <strong>report publication date (4/21)</strong> and the Q2 figures as at <strong>quarter-end (6/30)</strong>. Because the reference dates differ, <strong>the changes in this table are not a quarter-on-quarter comparison</strong> and should be read as "change against the value the previous report disclosed". Following the change of reference date in §2.3, <strong>like-for-like quarter-on-quarter figures begin with Q2→Q3</strong>.</p>
+
+<!-- ================= §3 ================= -->
+<h2 class="section" id="s3"><span class="num">§3</span><span class="lang-ko">분기 맥락과 전략 방향</span><span class="lang-en">Quarter Context &amp; Strategy</span></h2>
+
+<h3 id="s3.1">3.1 <span class="lang-ko">분기 맥락 — 현실이 루프에 들어오다</span><span class="lang-en">Quarter Context</span></h3>
+<p class="lang-ko">1분기가 지식 베이스(AEC-Fundamentals)·실험 엔진(Algora·AO·BRIDGE)·신뢰성 계층(ARK)을 쌓는 <em>인프라 구간</em>이었다면, 2분기는 그 인프라가 네 방향에서 현실과 접점을 만든 구간입니다.</p><p class="lang-en">If Q1 was an <em>infrastructure stretch</em> — building the knowledge base (AEC-Fundamentals), the experiment engines (Algora · AO · BRIDGE) and the reliability layer (ARK) — Q2 is the stretch in which that infrastructure met reality on four fronts.</p>
+<ol>
+  <li><span class="lang-ko"><strong>실제 건물</strong> — 디지털 트윈 트랙이 추적 커밋 기록의 55.8%를 차지하며, 실건물 운영 트윈(CCTV 감지·IoT 디바이스 매핑·재실 신호)이 가동을 시작했습니다. 4/21에는 국토부 AX Sprint R&amp;D 컨소시엄 참여를 공시했고, 6/25 정부 선정 결과가 발표되었습니다(후속 공시는 분기 내 미발행 → 분기 종료 후 2026-08-04 발행 — §7.1). (§7.1)</span><span class="lang-en"><strong>A real building</strong> — the digital twin track accounts for 55.8% of recorded commits, and the live-building operations twin (CCTV detection, IoT device mapping, occupancy signals) began running. Participation in the MOLIT AX Sprint R&amp;D consortium was disclosed on 4/21, and the government selection result was announced on 6/25 (the follow-up disclosure was not published within the quarter → published 2026-08-04 — §7.1). (§7.1)</span></li>
+  <li><span class="lang-ko"><strong>실제 주소</strong> — 5월 AI 미디어 클러스터 6종, 6월 links·Passport가 공개되어 실험이 <code>*.moss.land</code> 서비스로 전환되었습니다. (§5)</span><span class="lang-en"><strong>Real addresses</strong> — six AI media cluster services in May, then links and Passport in June, turned experiments into <code>*.moss.land</code> services. (§5)</span></li>
+  <li><span class="lang-ko"><strong>실제 지갑</strong> — Passport 오픈베타로 홀더가 자가지갑 서명으로 보유·참여를 증명하는 경로가 열렸고, 거래소 보관 물량의 자가지갑 전환을 보전하는 체계(Activation Support·Exit Pass)가 도입되었습니다. (§7.2)</span><span class="lang-en"><strong>Real wallets</strong> — Passport's open beta opened a path for holders to prove holdings and participation by self-custody signature, and a scheme to support moving exchange-held balances into self-custody (Activation Support · Exit Pass) was introduced. (§7.2)</span></li>
+  <li><span class="lang-ko"><strong>실제 판결</strong> — 2024년 제기된 소송이 대법원에서 최종 종결되어 장기 법적 불확실성 하나가 해소되었습니다. (§9.1)</span><span class="lang-en"><strong>A real judgment</strong> — the litigation filed in 2024 reached final conclusion at the Supreme Court, removing one long-running legal uncertainty. (§9.1)</span></li>
+</ol>
+<p class="lang-ko">같은 기간 시장 환경은 우호적이지 않았습니다. MOC 가격은 52주 저점 부근에서 분기를 마감했고(§2.3), 재단은 가격 대응성 이벤트보다 참여 인프라·검증 가능성에 개발 자원을 배분하는 선택을 유지했습니다. 이 선택의 근거와 한계는 §11 인사이트에서 다룹니다.</p><p class="lang-en">Market conditions over the same period were not favourable. MOC closed the quarter near its 52-week low (§2.3), and the Foundation continued to allocate development resources to participation infrastructure and verifiability rather than to price-responsive events. The reasoning and the limits of that choice are discussed in the §11 insights.</p>
+
+<h3 id="s3.2">3.2 <span class="lang-ko">2026년 전략 4대 축 — 분기 진척</span><span class="lang-en">The Four Strategic Axes for 2026 — Q2 Progress</span></h3>
+<p class="lang-ko">1분기 리포트 §3.2에서 정의한 4대 축 기준의 진척입니다. 이번 분기의 무게중심은 ④ 디지털 트윈으로 이동했습니다.</p><p class="lang-en">Progress against the four axes defined in §3.2 of the Q1 report. This quarter's centre of gravity moved to ④ the digital twin.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">축</span><span class="lang-en">Axis</span></th><th><span class="lang-ko">Q1 상태</span><span class="lang-en">Q1 status</span></th><th><span class="lang-ko">Q2 진척</span><span class="lang-en">Q2 progress</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">① 지식·엔지니어링 기반</span><span class="lang-en">① Knowledge · engineering base</span></td><td><span class="lang-ko">Q1 커밋의 74% (AEC 244 등)</span><span class="lang-en">74% of Q1 commits (AEC 244 and others)</span></td><td><span class="lang-ko">정비기. 커밋 기준 활동 저조 — AEC-Fundamentals는 분기 중 커밋 0건(이슈 단위 지식 활동은 별도 집계). Heymark는 6/5 소개 포스트로 대외 공개.</span><span class="lang-en">A consolidation period. Activity was low on a commit basis — AEC-Fundamentals recorded 0 commits during the quarter (issue-level knowledge work is counted separately). Heymark was published externally with an introductory post on 6/5.</span></td></tr>
+    <tr><td><span class="lang-ko">② 에이전트 기반 거버넌스</span><span class="lang-en">② Agent-based governance</span></td><td><span class="lang-ko">실험 가동 (Experimental · Human-locked)</span><span class="lang-en">Experiments running (Experimental · Human-locked)</span></td><td><span class="lang-ko">155커밋. Algora 공개 서비스 수준 정비 완료, AO 안정화 작업(§7.4), BRIDGE 연구 유지. 6월 Algora·BRIDGE 소개 포스트 발행.</span><span class="lang-en">155 commits. Algora completed its public-service-grade overhaul, AO focused on stabilisation (§7.4), and BRIDGE remained at research stage. Introductory posts for Algora and BRIDGE were published in June.</span></td></tr>
+    <tr><td><span class="lang-ko">③ 공시·커뮤니케이션 인프라</span><span class="lang-en">③ Disclosure · communications infrastructure</span></td><td><span class="lang-ko">대시보드 10개 섹션 상시 공개</span><span class="lang-en">10 dashboard sections published on an ongoing basis</span></td><td><span class="lang-ko">공식 공시 2건 · Q1 리포트 v2.1 발행(4/22) · links.moss.land 신설(6/29) — 공식 링크의 단일 기준점 확립.</span><span class="lang-en">2 official disclosures · Q1 report v2.1 published (4/22) · links.moss.land launched (6/29), establishing a single reference point for official links.</span></td></tr>
+    <tr><td><span class="lang-ko">④ 디지털 트윈 · Physical AI</span><span class="lang-en">④ Digital twin · Physical AI</span></td><td><span class="lang-ko">MossDT Engine PoC 슬라이스 (3월 말)</span><span class="lang-en">MossDT Engine PoC slice (end of March)</span></td><td><span class="lang-ko"><strong>1,086커밋 (가장 많은 커밋이 기록된 기술축).</strong> 렌더링·변환 엔진 본격화 + 실건물 운영 트윈 가동 + 4/21 컨소시엄 참여 공시. (§7.1)</span><span class="lang-en"><strong>1,086 commits (the technical track with the most recorded commits).</strong> The rendering/conversion engine moved into full development, the live-building operations twin went into service, and consortium participation was disclosed on 4/21. (§7.1)</span></td></tr>
+  </tbody>
+</table>
+
+<h3 id="s3.3">3.3 <span class="lang-ko">분기 타임라인</span><span class="lang-en">Quarterly Timeline</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">날짜</span><span class="lang-en">Date</span></th><th><span class="lang-ko">이벤트</span><span class="lang-en">Event</span></th><th><span class="lang-ko">구분</span><span class="lang-en">Type</span></th></tr></thead>
+  <tbody>
+    <tr><td>04-21</td><td><span class="lang-ko">국토부 AX Sprint R&amp;D 컨소시엄 참여 공시 (KO/EN PDF)</span><span class="lang-en">Disclosure of participation in the MOLIT AX Sprint R&amp;D consortium (KO/EN PDF)</span></td><td><span class="lang-ko">공시</span><span class="lang-en">Disclosure</span></td></tr>
+    <tr><td>04-22</td><td><span class="lang-ko">2026 Q1 리포트 v2.1 발행</span><span class="lang-en">2026 Q1 report v2.1 published</span></td><td><span class="lang-ko">공시</span><span class="lang-en">Disclosure</span></td></tr>
+    <tr><td>04-24</td><td><span class="lang-ko">2026 Q1 진행사항 요약 포스트 (KO/EN)</span><span class="lang-en">2026 Q1 progress summary post (KO/EN)</span></td><td><span class="lang-ko">블로그</span><span class="lang-en">Blog</span></td></tr>
+    <tr><td>04-30 ~ 05-12</td><td><span class="lang-ko">AI 미디어 클러스터 집중 구축 — Signal Map · Media · NPC · Alpha · Recipe · City 저장소 개설 및 순차 공개</span><span class="lang-en">Intensive build-out of the AI media cluster — Signal Map · Media · NPC · Alpha · Recipe · City repositories created and published in sequence</span></td><td><span class="lang-ko">서비스</span><span class="lang-en">Service</span></td></tr>
+    <tr><td>04-30</td><td><span class="lang-ko">WEEKLY AI HOT 5 포스트</span><span class="lang-en">WEEKLY AI HOT 5 post</span></td><td><span class="lang-ko">블로그</span><span class="lang-en">Blog</span></td></tr>
+    <tr><td>05-11 · 05-12</td><td><span class="lang-ko">LLM 정보 큐레이션 실험 포스트 (KO/EN 페어) · Alpha 소개 포스트 (EN)</span><span class="lang-en">LLM information-curation experiment post (KO/EN pair) · Alpha introduction post (EN)</span></td><td><span class="lang-ko">블로그</span><span class="lang-en">Blog</span></td></tr>
+    <tr><td>05-14</td><td><span class="lang-ko">AI EXPO KOREA 2026 참관 리뷰 2편 (전시 · 세미나)</span><span class="lang-en">AI EXPO KOREA 2026 visit reviews, 2 posts (exhibition · seminar)</span></td><td><span class="lang-ko">블로그</span><span class="lang-en">Blog</span></td></tr>
+    <tr><td>05-21 · 05-29</td><td><span class="lang-ko">NPC 실험 · MOSSLAND CITY 실험 노트 포스트 (KO/EN 페어)</span><span class="lang-en">NPC experiment · MOSSLAND CITY experiment note posts (KO/EN pairs)</span></td><td><span class="lang-ko">블로그</span><span class="lang-en">Blog</span></td></tr>
+    <tr><td>06-05</td><td><span class="lang-ko">Heymark 포스트 (KO/EN 페어)</span><span class="lang-en">Heymark post (KO/EN pair)</span></td><td><span class="lang-ko">블로그</span><span class="lang-en">Blog</span></td></tr>
+    <tr><td>06-09 ~ 06-10</td><td><span class="lang-ko">Passport 개발 착수 → 익일 첫 배포</span><span class="lang-en">Passport development started → first deployment the next day</span></td><td><span class="lang-ko">서비스</span><span class="lang-en">Service</span></td></tr>
+    <tr><td>06-11</td><td><span class="lang-ko">대법원 최종 판결 결과 공시 — 상고 기각, 소송 절차 종결</span><span class="lang-en">Disclosure of the Supreme Court's final judgment — appeal dismissed, proceedings concluded</span></td><td><span class="lang-ko">공시</span><span class="lang-en">Disclosure</span></td></tr>
+    <tr><td>06-17</td><td><span class="lang-ko">Algora 소개 포스트 (KO/EN 페어)</span><span class="lang-en">Algora introduction post (KO/EN pair)</span></td><td><span class="lang-ko">블로그</span><span class="lang-en">Blog</span></td></tr>
+    <tr><td>06-23 ~ 06-24</td><td><span class="lang-ko">Mossverse 배포 자동화 구축 · Passport 연동 도입</span><span class="lang-en">Mossverse deployment automation built · Passport integration introduced</span></td><td><span class="lang-ko">서비스</span><span class="lang-en">Service</span></td></tr>
+    <tr><td>06-25</td><td><span class="lang-ko">Agora 인증·보안 기반 재정비 착수 / Algora 공개 품질 정비 시작</span><span class="lang-en">Agora authentication/security rebuild started / Algora public-quality overhaul begun</span></td><td><span class="lang-ko">개발</span><span class="lang-en">Development</span></td></tr>
+    <tr><td>06-25</td><td><span class="lang-ko"><strong>국토교통부 AX Sprint 선정 결과 발표</strong> — <strong>국토교통부 소관 공모</strong>에서 총 26개 과제 최종 선정(국토·교통 14 · 도로·모빌리티 12), 재단 참여 컨소시엄의 과제 포함. 재단 후속 공시는 <strong>분기 내 미발행</strong> → 2026-08-04 발행(§7.1 · §1.2 항목 4 · §12).</span><span class="lang-en"><strong>MOLIT announced the AX Sprint selection results</strong> — 26 projects selected in total under <strong>its own call</strong> (Land &amp; Transport 14 · Road &amp; Mobility 12), including the project of the consortium in which the Foundation participates. The Foundation's follow-up disclosure was <strong>not published within the quarter</strong> → published 2026-08-04 (§7.1 · §1.2 item 4 · §12).</span></td><td><span class="lang-ko">외부</span><span class="lang-en">External</span></td></tr>
+    <tr><td>06-27</td><td><span class="lang-ko">MAIT 현대화 착수 — Spring Boot 4.1 · JDK 25</span><span class="lang-en">MAIT modernisation started — Spring Boot 4.1 · JDK 25</span></td><td><span class="lang-ko">개발</span><span class="lang-en">Development</span></td></tr>
+    <tr><td>06-29</td><td><span class="lang-ko">links.moss.land 공식 링크 허브 시작</span><span class="lang-en">links.moss.land official link hub launched</span></td><td><span class="lang-ko">서비스</span><span class="lang-en">Service</span></td></tr>
+    <tr><td>06-30</td><td><span class="lang-ko"><strong>Passport 오픈베타 공개</strong> · BRIDGE 포스트 (KO/EN) · Mossverse 보안 헤더 정리</span><span class="lang-en"><strong>Passport open beta published</strong> · BRIDGE post (KO/EN) · Mossverse security headers tidied</span></td><td><span class="lang-ko">서비스</span><span class="lang-en">Service</span></td></tr>
+  </tbody>
+</table>
+
+<h3 id="s3.4">3.4 <span class="lang-ko">상위 원칙 · 설계 규범</span><span class="lang-en">Top-Level Principles</span></h3>
+<p class="lang-ko">1분기에 공표한 5개 원칙은 변경 없이 유지됩니다. 2분기 중 이 원칙에 반하는 운영 사례는 확인되지 않았습니다.</p><p class="lang-en">The five principles declared in Q1 remain unchanged. No operational case contrary to these principles was identified during Q2.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">원칙</span><span class="lang-en">Principle</span></th><th><span class="lang-ko">설명</span><span class="lang-en">Description</span></th></tr></thead>
+  <tbody>
+    <tr><td>Human Sovereignty</td><td><span class="lang-ko">AI는 제안·분석·토론하지만, 고위험 행동(자금 이동, 파트너십 등)은 사람의 명시적 UNLOCK 전까지 잠금 상태. 모든 실험 시스템의 최우선 규범.</span><span class="lang-en">AI proposes, analyses and debates, but high-risk actions (moving funds, partnerships and the like) stay locked until a person explicitly UNLOCKs them. This is the first-order rule for every experimental system.</span></td></tr>
+    <tr><td>Auditability First</td><td><span class="lang-ko">모든 에이전트 출력에 출처 메타데이터(소스·시간·모델·해시) 포함. 의사결정 전 과정의 감사 추적 유지.</span><span class="lang-en">Every agent output carries provenance metadata (source, time, model, hash). An audit trail is kept across the whole decision process.</span></td></tr>
+    <tr><td>Reality Grounding</td><td><span class="lang-ko">거버넌스는 측정 가능한 현실 신호에서 시작. 정서적 표현·개인 의견은 신호가 아닌 입력으로만 간주.</span><span class="lang-en">Governance starts from measurable real-world signals. Emotional expression and personal opinion are treated as input, not as signal.</span></td></tr>
+    <tr><td>Reversibility</td><td><span class="lang-ko">롤백 가능성과 반대 의견은 일급(First-class) 개념. 실행은 원자적(all-or-none).</span><span class="lang-en">Reversibility and dissent are first-class concepts. Execution is atomic (all-or-none).</span></td></tr>
+    <tr><td>Gradual Automation</td><td><span class="lang-ko">자율화에 앞서 위임 단계를 둠. 권한은 정책·예산 상한·쿨다운으로 제한.</span><span class="lang-en">Delegation precedes autonomy. Authority is bounded by policy, budget ceilings and cooldowns.</span></td></tr>
+  </tbody>
+</table>
+
+<!-- ================= §4 ================= -->
+<h2 class="section" id="s4"><span class="num">§4</span><span class="lang-ko">커뮤니케이션 · 공시</span><span class="lang-en">Communications &amp; Disclosures</span></h2>
+
+<h3 id="s4.1">4.1 <span class="lang-ko">분기 요약</span><span class="lang-en">Quarterly Summary</span></h3>
+<div class="kpi">
+  <div class="cell"><div class="label">Blog Posts</div><div class="value">19</div><div class="unit"><span class="lang-ko">12개 주제 · 91일 <span class="vb v1">V1</span></span><span class="lang-en">12 topics · 91 days <span class="vb v1">V1</span></span></div></div>
+  <div class="cell"><div class="label">KO/EN Same-Day Pairs</div><div class="value">7 / 12</div><div class="unit"><span class="lang-ko">동일일 병행 발행 / 주제</span><span class="lang-en">Published same-day in both languages / topics</span></div></div>
+  <div class="cell"><div class="label">Official Disclosures</div><div class="value">2</div><div class="unit">04-21 · 06-11</div></div>
+  <div class="cell"><div class="label">Cadence</div><div class="value"><span class="lang-ko">5월 집중</span><span class="lang-en">May-heavy</span></div><div class="unit"><span class="lang-ko">4월 3건 · 5월 10건 · 6월 6건</span><span class="lang-en">April 3 · May 10 · June 6</span></div></div>
+</div>
+<p class="lang-ko">블로그 발행은 5월에 집중되었습니다 — 4월 3건(Q1 요약 KO/EN 2건 · WEEKLY AI HOT 5 1건), 5월 10건, 6월 6건입니다. 4월은 컨소시엄 공시(4/21)와 Q1 리포트 발행(4/22)이 커뮤니케이션의 중심이었고, 서비스 공개가 시작된 5월부터 각 서비스의 소개 포스트가 이어졌습니다. 1분기에 KO 단독 발행이 많았던 것과 달리, 2분기는 <strong>12개 주제 중 7개가 KO/EN 동일일 페어</strong>로 발행되어 국영문 병행 원칙이 정착되고 있습니다.</p><p class="lang-en">Blog publishing was concentrated in May — 3 posts in April (2 for the Q1 summary in KO/EN, 1 for WEEKLY AI HOT 5), 10 in May and 6 in June. April's communications centred on the consortium disclosure (4/21) and the Q1 report (4/22); from May, as services began to be published, introductory posts followed for each. Unlike Q1, where many posts appeared in Korean only, <strong>7 of the 12 topics in Q2 were published as same-day KO/EN pairs</strong>, so the bilingual practice is taking hold.</p>
+<p class="lang-ko">한편 <strong>2분기 최대 규모의 서비스 공개였던 Passport(6/9 착수 → 6/30 오픈베타)는 소개 포스트 없이 진행</strong>되었습니다. 서비스는 공개되었으나 그 의미를 설명하는 커뮤니케이션이 같은 분기 안에 따라붙지 못한 사례입니다. 소개 포스트는 분기 종료 8일 후인 7/8에 KO/EN 페어로 발행되었으며(§12), 본 리포트는 이를 누락이 아니라 공개–설명 간 시차로 기록하고, 신규 서비스 공개와 소개 포스트의 동일 분기 내 발행을 3분기 원칙으로 고정합니다(§13.1).</p><p class="lang-en">On the other hand, <strong>Passport — the quarter's largest service launch (started 6/9 → open beta 6/30) — went out without an introductory post</strong>. The service was published, but the communication explaining what it meant did not follow within the same quarter. The introductory post was published as a KO/EN pair on 7/8, eight days after quarter-end (§12). This report records it as a lag between launch and explanation rather than an omission, and sets same-quarter publication of an introductory post alongside any new service launch as a Q3 rule (§13.1).</p>
+
+<h3 id="s4.2">4.2 <span class="lang-ko">포스트별 심층 요약</span><span class="lang-en">Per-Post Deep Dive</span></h3>
+<div class="posts">
+  <div class="p">
+    <div class="d">2026-04-24 · KO/EN</div>
+    <div class="t"><span class="lang-ko">2026 Q1 진행사항 요약 — 개발 기록에서 Physical AI 연구까지</span><span class="lang-en">2026 Q1 progress summary — from development records to Physical AI research</span></div>
+    <div class="s">
+      <p class="lang-ko">1분기 리포트의 요약판. 유통량·공시·공개 저장소 집계(MosslandOpenDevs 448커밋)·에이전트 실험의 역할 구분·MossDT Engine(가칭) 내부 탐색을 정리하고, 해당 내부 연구가 정부 R&amp;D 컨소시엄 신청 건과 별개임을 명시했습니다.</p><p class="lang-en">A condensed version of the Q1 report. It covered circulating supply, disclosures, the public repository count (448 commits in MosslandOpenDevs), the division of roles across the agent experiments, and internal exploration of the MossDT Engine (working title), and stated explicitly that this internal research was separate from the government R&amp;D consortium application.</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/2026-q1-progress-summary-8e337567c9cb" target="_blank" rel="noopener">EN</a> · KO</p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-04-30 · KO</div>
+    <div class="t"><span class="lang-ko">WEEKLY AI HOT 5</span><span class="lang-en">WEEKLY AI HOT 5</span></div>
+    <div class="s">
+      <p class="lang-ko">주간 AI 화제 5선을 짧게 정리한 큐레이션 포스트(1분 분량). 2분기 유일한 단발 큐레이션 형식이며, 이후 정기 시리즈로 이어지지는 않았습니다.</p><p class="lang-en">A short curation post (about a minute's read) rounding up five AI talking points of the week. It was the only one-off curation format in Q2 and did not continue as a regular series.</p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-05-11 · KO/EN</div>
+    <div class="t"><span class="lang-ko">모스랜드 LLM 기반 정보 큐레이션 실험: Alpha, Signal Map, MOSS stance graph</span><span class="lang-en">Mossland's LLM-based information curation experiment: Alpha, Signal Map, MOSS stance graph</span></div>
+    <div class="s">
+      <p class="lang-ko">YouTube·뉴스·매크로 피드를 정규화하는 Signal Map 파이프라인과, 그 위에서 동작하는 크립토 버티컬 미디어 Alpha(스탠스 분포·AI 데일리 브리프·RAG Q&amp;A·MCP 12툴)를 공개. "사람과 LLM 모두가 인용할 수 있는 미디어"라는 설계 목표를 공식화했습니다.</p><p class="lang-en">Published the Signal Map pipeline, which normalises YouTube, news and macro feeds, and Alpha, the crypto vertical media running on top of it (stance distribution, AI daily brief, RAG Q&amp;A, 12 MCP tools). It formalised the design goal of "media that both people and LLMs can cite".</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/%EB%AA%A8%EC%8A%A4%EB%9E%9C%EB%93%9C-llm-%EA%B8%B0%EB%B0%98-%EC%A0%95%EB%B3%B4-%ED%81%90%EB%A0%88%EC%9D%B4%EC%85%98-%EC%8B%A4%ED%97%98-alpha-signal-map-moss-stance-graph-8ef0568dae60" target="_blank" rel="noopener">KO</a> · EN</p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-05-12 · EN</div>
+    <div class="t">Alpha — Crypto, Read by LLMs</div>
+    <div class="s">
+      <p class="lang-ko">Alpha를 &ldquo;LLM이 읽는 크립토 매체&rdquo;로 소개한 짧은 영문 포스트(3분 분량). 전일 발행된 큐레이션 실험 포스트의 영문판이 아니라 별도 발행분입니다.</p><p class="lang-en">A short English post (about a three-minute read) introducing Alpha as "crypto, read by LLMs". It is a separate piece rather than an English version of the curation-experiment post published the previous day.</p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-05-14 · KO ×2</div>
+    <div class="t">AI EXPO KOREA 2026 (1) · (2) — <span class="lang-ko">전시 · 세미나 리뷰</span><span class="lang-en">Exhibition · seminar reviews</span></div>
+    <div class="s">
+      <p class="lang-ko">AI EXPO KOREA 2026(5/6~8, COEX) 참관 기록 2편 — 전시 부문 리뷰와 세미나 부문 리뷰. 2분기 중 유일한 외부 행사 참관 콘텐츠입니다.</p><p class="lang-en">Two records of attending AI EXPO KOREA 2026 (5/6–8, COEX) — one reviewing the exhibition, one the seminars. This was the only external-event content in Q2.</p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-05-21 · KO/EN</div>
+    <div class="t"><span class="lang-ko">모스랜드 NPC 실험: AI 주민들과 대화하는 도시</span><span class="lang-en">Mossland's NPC experiment: a city where you talk to AI residents</span></div>
+    <div class="s">
+      <p class="lang-ko">세션이 끝나면 잊는 무상태 LLM 에이전트의 한계를 넘어, 페르소나·장기 기억을 가진 디지털 주민을 만드는 실험을 소개. 매일 밤 시장·뉴스·커뮤니티 흐름을 각 캐릭터의 목소리로 헤드라인화하는 파이프라인을 설명했습니다.</p><p class="lang-en">Introduced an experiment in creating digital residents with persona and long-term memory, going beyond the limits of stateless LLM agents that forget once a session ends. It described a pipeline that turns each night's market, news and community flows into headlines in each character's voice.</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/%EB%AA%A8%EC%8A%A4%EB%9E%9C%EB%93%9C-npc-%EC%8B%A4%ED%97%98-ai-%EC%A3%BC%EB%AF%BC%EB%93%A4%EA%B3%BC-%EB%8C%80%ED%99%94%ED%95%98%EB%8A%94-%EB%8F%84%EC%8B%9C-d7016bf7529f" target="_blank" rel="noopener">KO</a> · <a href="https://medium.com/mossland-blog/mossland-npc-experiment-a-city-where-users-talk-with-ai-residents-11a9e2343c84" target="_blank" rel="noopener">EN</a></p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-05-22 · KO</div>
+    <div class="t"><span class="lang-ko">AI에게 묻는 시대에서, AI에게 맡기는 시대로</span><span class="lang-en">From asking AI to delegating to AI</span></div>
+    <div class="s">
+      <p class="lang-ko">질의응답형 AI 활용에서 위임형(에이전트) 활용으로의 전환을 다룬 방향성 칼럼. 에이전트 중심 전략(§3)의 대중 커뮤니케이션 버전입니다.</p><p class="lang-en">A direction-setting column on the shift from question-and-answer use of AI to delegated (agent) use. It is the general-audience version of the agent-centred strategy in §3.</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/ai%EC%97%90%EA%B2%8C-%EB%AC%BB%EB%8A%94-%EC%8B%9C%EB%8C%80%EC%97%90%EC%84%9C-ai%EC%97%90%EA%B2%8C-%EB%A7%A1%EA%B8%B0%EB%8A%94-%EC%8B%9C%EB%8C%80%EB%A1%9C-91614e1ca185" target="_blank" rel="noopener">KO</a></p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-05-29 · KO/EN</div>
+    <div class="t"><span class="lang-ko">MOSSLAND CITY 실험 노트</span><span class="lang-en">MOSSLAND CITY experiment notes</span></div>
+    <div class="s">
+      <p class="lang-ko">NPC·Alpha·Algora·AO·BRIDGE의 실시간 신호를 하나의 거주 가능한 가상 도시로 집약하는 대규모 사회 시뮬레이션 실험을 소개. 닫힌 샌드박스가 아니라 인간 사회의 실시간 신호 위에서 실험한다는 점을 명시했습니다.</p><p class="lang-en">Introduced a large-scale social simulation that gathers real-time signals from NPC, Alpha, Algora, AO and BRIDGE into a single habitable virtual city. It made explicit that the experiment runs on real-time signals from human society rather than in a closed sandbox.</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/mossland-city-%EC%8B%A4%ED%97%98-%EB%85%B8%ED%8A%B8-62fa0cc3991a" target="_blank" rel="noopener">KO</a> · <a href="https://medium.com/mossland-blog/mossland-city-experiment-note-bc837bb5bf3b" target="_blank" rel="noopener">EN</a></p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-06-05 · KO/EN</div>
+    <div class="t"><span class="lang-ko">Heymark: AI 작업 기준 관리</span><span class="lang-en">Heymark: managing standards for AI work</span></div>
+    <div class="s">
+      <p class="lang-ko">AI 코딩 어시스턴트별로 흩어지는 규칙·스킬을 단일 소스에서 동기화하는 Heymark를 소개. 모스랜드 전체 멀티 에이전트 개발 워크플로우의 기반 도구임을 공식화했습니다.</p><p class="lang-en">Introduced Heymark, which synchronises rules and skills — otherwise scattered across individual AI coding assistants — from a single source. It formalised the tool as the foundation of Mossland's multi-agent development workflow.</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/heymark-ai-%EC%9E%91%EC%97%85-%EA%B8%B0%EC%A4%80-%EA%B4%80%EB%A6%AC-93127f4af0c6" target="_blank" rel="noopener">KO</a> · <a href="https://medium.com/mossland-blog/heymark-managing-ai-work-standards-7c8a823be55f" target="_blank" rel="noopener">EN</a></p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-06-17 · KO/EN</div>
+    <div class="t"><span class="lang-ko">Algora: AI가 토론하고, 사람이 결정하는 광장</span><span class="lang-en">Algora: a forum where AI debates and people decide</span></div>
+    <div class="s">
+      <p class="lang-ko">24/7 에이전트 거버넌스 실험 Algora의 공개 버전 소개. 에이전트가 신호를 수집·토론하되 고위험 행동은 사람의 승인까지 잠금(LOCK)이라는 Human Sovereignty 원칙을 대중 언어로 설명했습니다.</p><p class="lang-en">Introduced the public version of Algora, the 24/7 agent governance experiment. It explained the Human Sovereignty principle in plain language: agents gather signals and debate, but high-risk actions stay LOCKed until a person approves them.</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/algora-ai%EA%B0%80-%ED%86%A0%EB%A1%A0%ED%95%98%EA%B3%A0-%EC%82%AC%EB%9E%8C%EC%9D%B4-%EA%B2%B0%EC%A0%95%ED%95%98%EB%8A%94-%EA%B4%91%EC%9E%A5-e0a222bc8367" target="_blank" rel="noopener">KO</a> · <a href="https://medium.com/mossland-blog/algora-where-ai-agents-deliberate-and-humans-decide-bf6b1f164341" target="_blank" rel="noopener">EN</a></p>
+    </div>
+  </div>
+  <div class="p">
+    <div class="d">2026-06-30 · KO/EN</div>
+    <div class="t"><span class="lang-ko">BRIDGE: 현실 신호가 거버넌스 의제가 되는 실험</span><span class="lang-en">BRIDGE: an experiment in turning real-world signals into governance agenda</span></div>
+    <div class="s">
+      <p class="lang-ko">Reality Oracle → Inference Mining → Agentic Consensus 루프를 구현하는 Physical AI Governance OS 연구 프리뷰를 소개. 분기 마지막 날 발행되어 3분기 방향(현실 신호 기반 거버넌스)을 예고했습니다.</p><p class="lang-en">Introduced a research preview of a Physical AI Governance OS implementing the Reality Oracle → Inference Mining → Agentic Consensus loop. Published on the last day of the quarter, it previewed the Q3 direction of governance grounded in real-world signals.</p>
+      <p class="small"><a href="https://medium.com/mossland-blog/bridge-%ED%98%84%EC%8B%A4-%EC%8B%A0%ED%98%B8%EA%B0%80-%EA%B1%B0%EB%B2%84%EB%84%8C%EC%8A%A4-%EC%9D%98%EC%A0%9C%EA%B0%80-%EB%90%98%EB%8A%94-%EC%8B%A4%ED%97%98-ce68be4f48f8" target="_blank" rel="noopener">KO</a> · <a href="https://medium.com/mossland-blog/bridge-where-reality-signals-become-governance-agendas-6644b63f98e2" target="_blank" rel="noopener">EN</a></p>
+    </div>
+  </div>
+</div>
+
+<h3 id="s4.3">4.3 <span class="lang-ko">공식 공시 (2건)</span><span class="lang-en">Official Disclosures (2)</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">날짜</span><span class="lang-en">Date</span></th><th><span class="lang-ko">공시 제목</span><span class="lang-en">Disclosure title</span></th><th><span class="lang-ko">원문</span><span class="lang-en">Source</span></th></tr></thead>
+  <tbody>
+    <tr>
+      <td>2026-04-21</td>
+      <td><span class="lang-ko">국토부 AX Sprint R&amp;D 컨소시엄 — 공동연구·국제표준화 협력기관 참여 (컨소시엄 구성·신청 단계, 당시 선정 결과 대기) · 문서번호 MOSS-DISC-2026-0421 · <strong>6/25 선정 발표 · 7/10 협약 체결 → 후속 공시는 분기 종료 후 2026-08-04 발행(MOSS-DISC-2026-0804 · §7.1 · §12)</strong></span><span class="lang-en">MOLIT AX Sprint R&amp;D consortium — participation as a joint-research and international-standardisation cooperating institution (consortium formation and application stage; selection result pending at the time) · document no. MOSS-DISC-2026-0421 · <strong>selection announced 6/25 · agreement executed 7/10 → the follow-up disclosure was published after quarter-end on 2026-08-04 (MOSS-DISC-2026-0804 · §7.1 · §12)</strong></span></td>
+      <td><a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-04-21_ax-sprint-consortium-participation.pdf" target="_blank" rel="noopener">KO PDF</a> · <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-04-21_ax-sprint-consortium-participation_en.pdf" target="_blank" rel="noopener">EN PDF</a></td>
+    </tr>
+    <tr>
+      <td>2026-06-11</td>
+      <td><span class="lang-ko">2024-01-29 「소송 등의 제기」 공시 후속 — 대법원 최종 판결 결과 공시 (상고 기각 · 절차 종결)</span><span class="lang-en">Follow-up to the 2024-01-29 "Notice of Litigation Commencement" — disclosure of the Supreme Court's final judgment (appeal dismissed · proceedings concluded)</span></td>
+      <td><a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-06-11_final-judgment-result_to_2024-01-29_litigation-disclosure.md" target="_blank" rel="noopener">GitHub</a></td>
+    </tr>
+  </tbody>
+</table>
+<p class="small lang-ko">컨소시엄 공시의 사업 구조는 §7.1, 판결의 상세와 법인격 관계는 §9.1에서 정리합니다. 위 2건은 <strong>보고 기간(4/1~6/30) 내 발행분</strong>입니다. AX Sprint 선정·협약에 대한 후속 공시(MOSS-DISC-2026-0804)는 분기 종료 후인 2026-08-04에 발행되어 본 표에 포함되지 않으며, 3분기 공시 실적으로 집계됩니다(§12).</p><p class="small lang-en">The business structure behind the consortium disclosure is set out in §7.1, and the details of the judgment and the corporate relationships in §9.1. Both items above were <strong>published within the reporting period (4/1–6/30)</strong>. The follow-up disclosure on the AX Sprint selection and agreement (MOSS-DISC-2026-0804) was published on 2026-08-04, after quarter-end, so it is not included in this table and will count towards Q3 disclosures (§12).</p>
+
+<h3 id="s4.4">4.4 <span class="lang-ko">공시 대시보드 · 상시 공개</span><span class="lang-en">Disclosure Dashboard</span></h3>
+<p class="lang-ko">재단은 분기 리포트 외에도 <a href="https://disclosure.moss.land" target="_blank" rel="noopener">disclosure.moss.land</a>에서 시장·유통량·온체인·DAO·개발·에이전트 시스템(Algora·AO·BRIDGE) 지표를 상시 공개합니다. 2분기 중 재단 지갑 주소 상시 공개(§2.5)와 유통량 변동 사전 예고(§2.7)가 대시보드에 반영되었습니다. 한편 대시보드의 개발 활동 수치는 본 리포트와 추적 저장소 범위가 달라 차이가 있으며(§A.4), 집계 범위 정합화를 3분기 과제로 공식화합니다(§13).</p><p class="lang-en">Beyond the quarterly report, the Foundation publishes market, circulating supply, on-chain, DAO, development and agent-system (Algora · AO · BRIDGE) indicators on an ongoing basis at <a href="https://disclosure.moss.land" target="_blank" rel="noopener">disclosure.moss.land</a>. During Q2 the ongoing publication of the Foundation wallet address (§2.5) and advance notice of circulating-supply changes (§2.7) were reflected on the dashboard. The dashboard's development figures differ from this report because the tracked repository scope differs (§A.4); reconciling the scope is formalised as a Q3 task (§13).</p>
+
+<h3 id="s4.5">4.5 <span class="lang-ko">소셜 · 커뮤니티 채널</span><span class="lang-en">Social &amp; Community Channels</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">채널</span><span class="lang-en">Channel</span></th><th><span class="lang-ko">용도</span><span class="lang-en">Purpose</span></th><th>URL</th></tr></thead>
+  <tbody>
+    <tr><td>Link Hub <strong class="lang-ko">(신규)</strong><strong class="lang-en">(new)</strong></td><td><span class="lang-ko">공식 링크 일람 — 여기 없는 주소는 공식이 아님 (사칭·피싱 대응 기준점)</span><span class="lang-en">Index of official links — an address not listed here is not official (the reference point for responding to impersonation and phishing)</span></td><td><a href="https://links.moss.land" target="_blank" rel="noopener">links.moss.land</a></td></tr>
+    <tr><td>Medium Blog</td><td><span class="lang-ko">장문 공식 커뮤니케이션, 국영문 병행 발행 원칙</span><span class="lang-en">Long-form official communication, published in Korean and English in parallel</span></td><td><a href="https://medium.com/mossland-blog" target="_blank" rel="noopener">medium.com/mossland-blog</a></td></tr>
+    <tr><td>X (Twitter)</td><td><span class="lang-ko">단문 공지·이벤트·커뮤니티 피드백</span><span class="lang-en">Short notices, events and community feedback</span></td><td><a href="https://x.com/TheMossland" target="_blank" rel="noopener">x.com/TheMossland</a></td></tr>
+    <tr><td>Agora Forum</td><td><span class="lang-ko">거버넌스 안건(MIP) 토론·투표</span><span class="lang-en">Governance agenda (MIP) discussion and voting</span></td><td><a href="https://agora.moss.land" target="_blank" rel="noopener">agora.moss.land</a></td></tr>
+    <tr><td>GitHub · mossland</td><td><span class="lang-ko">공시 저장소 및 프로젝트 포털</span><span class="lang-en">Disclosure repository and project portal</span></td><td><a href="https://github.com/mossland" target="_blank" rel="noopener">github.com/mossland</a></td></tr>
+    <tr><td>GitHub · MosslandOpenDevs</td><td><span class="lang-ko">오픈소스·연구·실험 저장소 집합</span><span class="lang-en">Collection of open-source, research and experimental repositories</span></td><td><a href="https://github.com/MosslandOpenDevs" target="_blank" rel="noopener">github.com/MosslandOpenDevs</a></td></tr>
+  </tbody>
+</table>
+
+<!-- ================= §5 ================= -->
+<h2 class="section" id="s5"><span class="num">§5</span><span class="lang-ko">서비스 카탈로그</span><span class="lang-en">Service Catalog</span></h2>
+<p class="lang-ko">아래 목록은 links.moss.land 공식 목록(최종 확인 2026-07-06) 기준으로 라이브 상태인 <code>*.moss.land</code> 도메인 전체입니다. 상태 표기는 links.moss.land의 공식 분류를 따르며, <strong>이 목록에 없는 주소는 모스랜드 공식 서비스가 아닙니다.</strong> 2분기 신규 공개는 굵게 표시했습니다. 공식 커뮤니케이션 채널(Medium·X)은 <code>*.moss.land</code> 도메인이 아니지만 독자 편의를 위해 함께 실었으며, 도메인 집계에는 포함하지 않습니다. <span class="vb v2">V2</span></p><p class="lang-en">The list below is every <code>*.moss.land</code> domain that was live according to the official links.moss.land list (last verified 2026-07-06). Status labels follow the official classification on links.moss.land, and <strong>an address not on this list is not an official Mossland service.</strong> New launches in Q2 are shown in bold. The official communication channels (Medium · X) are not <code>*.moss.land</code> domains but are included for the reader's convenience; they are excluded from the domain count. <span class="vb v2">V2</span></p>
+<table>
+  <thead><tr><th><span class="lang-ko">구분</span><span class="lang-en">Type</span></th><th><span class="lang-ko">서비스</span><span class="lang-en">Service</span></th><th>URL</th><th><span class="lang-ko">상태</span><span class="lang-en">Status</span></th><th><span class="lang-ko">Q2 변화</span><span class="lang-en">Q2 change</span></th></tr></thead>
+  <tbody>
+    <tr><td rowspan="4"><span class="lang-ko">공식</span><span class="lang-en">Official</span></td><td>Mossland</td><td><a href="https://moss.land" target="_blank" rel="noopener">moss.land</a></td><td>Official</td><td><span class="lang-ko">2026-LABS 섹션 등 갱신</span><span class="lang-en">Updated sections including 2026-LABS</span></td></tr>
+    <tr><td data-label="서비스">Disclosure</td><td data-label="URL"><a href="https://disclosure.moss.land" target="_blank" rel="noopener">disclosure.moss.land</a></td><td data-label="상태">Official</td><td data-label="Q2 변화"><span class="lang-ko">지갑 공개·유통 예고 반영</span><span class="lang-en">Wallet publication and supply notices reflected</span></td></tr>
+    <tr><td data-label="서비스"><strong>links</strong></td><td data-label="URL"><a href="https://links.moss.land" target="_blank" rel="noopener">links.moss.land</a></td><td data-label="상태">Official</td><td data-label="Q2 변화"><span class="lang-ko"><strong>6/29 신규</strong> — 기계 판독용 registry·llms.txt 포함</span><span class="lang-en"><strong>New 6/29</strong> — includes a machine-readable registry and llms.txt</span></td></tr>
+    <tr><td data-label="서비스">Medium · X</td><td data-label="URL"><a href="https://medium.com/mossland-blog" target="_blank" rel="noopener">medium.com/mossland-blog</a> · <a href="https://x.com/TheMossland" target="_blank" rel="noopener">x.com/TheMossland</a></td><td data-label="상태">Official</td><td data-label="Q2 변화"><span class="lang-ko"><code>*.moss.land</code> 외 공식 채널 — 도메인 집계 제외 (§4.5)</span><span class="lang-en">Official channels outside <code>*.moss.land</code> — excluded from the domain count (§4.5)</span></td></tr>
+    <tr><td rowspan="3"><span class="lang-ko">참여</span><span class="lang-en">Participation</span></td><td><strong>Passport</strong></td><td><a href="https://passport.moss.land" target="_blank" rel="noopener">passport.moss.land</a></td><td>Beta</td><td><span class="lang-ko"><strong>6/30 오픈베타</strong> — §7.2</span><span class="lang-en"><strong>Open beta 6/30</strong> — §7.2</span></td></tr>
+    <tr><td data-label="서비스">Agora</td><td data-label="URL"><a href="https://agora.moss.land" target="_blank" rel="noopener">agora.moss.land</a></td><td data-label="상태">Official</td><td data-label="Q2 변화"><span class="lang-ko">6/25~ 인증 기반 재정비 착수</span><span class="lang-en">Authentication rebuild started from 6/25</span></td></tr>
+    <tr><td data-label="서비스">Mossverse</td><td data-label="URL"><a href="https://wa.moss.land" target="_blank" rel="noopener">wa.moss.land</a> · <a href="https://play.wa.moss.land" target="_blank" rel="noopener">play.wa.moss.land</a></td><td data-label="상태">Beta</td><td data-label="Q2 변화"><span class="lang-ko">Passport 연동 최초 적용</span><span class="lang-en">First service to adopt the Passport integration</span></td></tr>
+    <tr><td rowspan="10"><span class="lang-ko">생태계</span><span class="lang-en">Ecosystem</span></td><td><strong>Alpha</strong></td><td><a href="https://alpha.moss.land" target="_blank" rel="noopener">alpha.moss.land</a></td><td>Intelligence</td><td><span class="lang-ko"><strong>5월 공개</strong> — 크립토 버티컬 미디어 + MCP 12툴</span><span class="lang-en"><strong>Published in May</strong> — crypto vertical media + 12 MCP tools</span></td></tr>
+    <tr><td data-label="서비스"><strong>Signal Map</strong></td><td data-label="URL"><a href="https://signalmap.moss.land" target="_blank" rel="noopener">signalmap.moss.land</a></td><td data-label="상태">Intelligence</td><td data-label="Q2 변화"><span class="lang-ko"><strong>5월 공개</strong> — 멀티소스 내러티브 파이프라인</span><span class="lang-en"><strong>Published in May</strong> — multi-source narrative pipeline</span></td></tr>
+    <tr><td data-label="서비스"><strong>Media</strong></td><td data-label="URL"><a href="https://media.moss.land" target="_blank" rel="noopener">media.moss.land</a></td><td data-label="상태">Experimental</td><td data-label="Q2 변화"><span class="lang-ko"><strong>5월 공개</strong> — 스탠스 기반 미디어 + 커뮤니티</span><span class="lang-en"><strong>Published in May</strong> — stance-based media + community</span></td></tr>
+    <tr><td data-label="서비스"><strong>City</strong></td><td data-label="URL"><a href="https://city.moss.land" target="_blank" rel="noopener">city.moss.land</a></td><td data-label="상태">Showcase</td><td data-label="Q2 변화"><span class="lang-ko"><strong>5월 공개</strong> — AI 사회 시뮬레이션</span><span class="lang-en"><strong>Published in May</strong> — AI social simulation</span></td></tr>
+    <tr><td data-label="서비스"><strong>NPC</strong></td><td data-label="URL"><a href="https://npc.moss.land" target="_blank" rel="noopener">npc.moss.land</a></td><td data-label="상태">Showcase</td><td data-label="Q2 변화"><span class="lang-ko"><strong>5월 공개</strong> — 장기 기억 디지털 주민</span><span class="lang-en"><strong>Published in May</strong> — digital residents with long-term memory</span></td></tr>
+    <tr><td data-label="서비스"><strong>Recipe</strong></td><td data-label="URL"><a href="https://recipe.moss.land" target="_blank" rel="noopener">recipe.moss.land</a></td><td data-label="상태">Showcase</td><td data-label="Q2 변화"><span class="lang-ko"><strong>5월 공개</strong> — AI 트렌드 레시피 갤러리</span><span class="lang-en"><strong>Published in May</strong> — AI trend recipe gallery</span></td></tr>
+    <tr><td data-label="서비스">MOSS.AO</td><td data-label="URL"><a href="https://ao.moss.land" target="_blank" rel="noopener">ao.moss.land</a></td><td data-label="상태">Experimental</td><td data-label="Q2 변화"><span class="lang-ko">§7.4 참조</span><span class="lang-en">See §7.4</span></td></tr>
+    <tr><td data-label="서비스">Algora</td><td data-label="URL"><a href="https://algora.moss.land" target="_blank" rel="noopener">algora.moss.land</a></td><td data-label="상태">Experimental</td><td data-label="Q2 변화"><span class="lang-ko">6월 말 공개 품질 정비</span><span class="lang-en">Public-quality overhaul in late June</span></td></tr>
+    <tr><td data-label="서비스">BRIDGE</td><td data-label="URL"><a href="https://bridge.moss.land" target="_blank" rel="noopener">bridge.moss.land</a></td><td data-label="상태">Experimental</td><td data-label="Q2 변화"><span class="lang-ko">연구 프리뷰 유지</span><span class="lang-en">Kept as a research preview</span></td></tr>
+    <tr><td data-label="서비스">Governance Monitor</td><td data-label="URL"><a href="https://monitor.moss.land" target="_blank" rel="noopener">monitor.moss.land</a></td><td data-label="상태">Experimental</td><td data-label="Q2 변화"><span class="lang-ko">픽셀 운영 맵</span><span class="lang-en">Pixel operations map</span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko">각 서비스의 공개 시점은 저장소 생성일·블로그 발행일 기준 추정이 포함되어 있으며, 월 단위로만 표기했습니다. 라이브 도메인 수는 <a href="https://links.moss.land" target="_blank" rel="noopener">links.moss.land</a>의 공식 목록(최종 확인 2026-07-06) 기준 <code>*.moss.land</code> 17개입니다. 이 중 <span class="mono">play.wa.moss.land</span>는 Mossverse의 플레이 접속 도메인으로 독립 서비스가 아니므로, <strong>독립 서비스 기준으로는 16개</strong>입니다. 이 목록은 <strong>2026-07-06 확인 시점</strong> 기준이며, 7월 초 종료된 MAIT는 7/3에 목록에서 제외되었습니다(§12). MAIT는 <strong>분기말(6/30) 시점에는 운영 중</strong>이었으므로(§7.3), 기준 시점별 수치는 다음과 같습니다 — <strong>분기말(2026-06-30): 도메인 18 · 독립 서비스 17</strong> / <strong>현재 목록(2026-07-06): 도메인 17 · 독립 서비스 16</strong>. 본 리포트의 대표 지표는 보고 기간에 맞춰 <strong>분기말 기준(18/17)</strong>을 사용하며, 아래 표는 현재 목록을 그대로 싣습니다. 재단은 MAIT의 도메인 주소를 본 리포트에서 별도 표기하지 않습니다.</p><p class="small lang-en">Publication dates for each service include estimates based on repository creation dates and blog publication dates, and are given only to the month. The live domain count is 17 <code>*.moss.land</code> domains on the official list at <a href="https://links.moss.land" target="_blank" rel="noopener">links.moss.land</a> (last checked 2026-07-06). Of these, <span class="mono">play.wa.moss.land</span> is Mossverse's play access domain rather than a separate service, so <strong>on a distinct-service basis the count is 16</strong>. That list is as at <strong>the 2026-07-06 check</strong>; MAIT, retired in early July, was removed from the list on 7/3 (§12). MAIT <strong>was still operating at quarter-end (6/30)</strong> (§7.3), so the figures by reference date are — <strong>quarter-end (2026-06-30): 18 domains · 17 distinct services</strong> / <strong>current list (2026-07-06): 17 domains · 16 distinct services</strong>. The headline figure in this report follows the reporting period and uses the <strong>quarter-end basis (18/17)</strong>, while the table below reproduces the current list as it stands. The Foundation does not separately state MAIT's domain address in this report.</p>
+
+<!-- ================= §6 ================= -->
+<h2 class="section" id="s6"><span class="num">§6</span><span class="lang-ko">기술 개발 현황</span><span class="lang-en">Technical Development</span></h2>
+
+<h3 id="s6.1">6.1 <span class="lang-ko">정의 · 집계 기준 변경 고지</span><span class="lang-en">Definitions &amp; Counting-Rule Changes</span></h3>
+<p class="lang-ko">이번 분기부터 개발 활동 집계 기준이 두 가지 변경됩니다. 변경은 수치를 좋게 보이기 위한 것이 아니라 실제 개발 구조를 반영하기 위한 것이며, 변경 전 기준의 수치(공개 커밋 259)도 §1.2에 그대로 공시했습니다.</p><p class="lang-en">Two changes to the development counting basis take effect this quarter. They are made to reflect the actual structure of development rather than to flatter the figures, and the figure on the previous basis (259 public commits) is disclosed unchanged in §1.2.</p>
+<ol>
+  <li><span class="lang-ko"><strong>집계 범위 확장 — 3개 GitHub 네임스페이스·비공개 포함.</strong> 기존 집계는 MosslandOpenDevs 공개 저장소만 대상이었습니다. 그러나 2분기 개발의 중심이 운영 서비스·컨소시엄 관련 저장소(비공개, MosslandCore)로 이동하여, 공개 저장소만으로는 분기 개발 실체를 설명할 수 없게 되었습니다. 이번 분기부터 <code>mossland</code> · <code>MosslandOpenDevs</code> · <code>MosslandCore</code> 3개 GitHub 네임스페이스, 공개·비공개 저장소를 함께 집계하되 공개·비공개를 분리 표기합니다. <strong>2026-08-03 현재 저장소 재고는 93개</strong>(공개 60 · 비공개 33)이며, 커밋 집계에서는 <strong>포크 2개를 제외한 91개</strong>(공개 58 · 비공개 33)를 모집단으로 삼았습니다(§A.3).</span><span class="lang-en"><strong>Wider scope — three GitHub namespaces, private repositories included.</strong> The previous count covered only public repositories in MosslandOpenDevs. In Q2, however, the centre of development moved to operational-service and consortium-related repositories (private, in MosslandCore), and public repositories alone could no longer describe what was actually built. From this quarter the count spans the three GitHub namespaces <code>mossland</code> · <code>MosslandOpenDevs</code> · <code>MosslandCore</code>, covering public and private repositories together while reporting them separately. <strong>As of 2026-08-03 the repository inventory is 93</strong> (public 60 · private 33), and the counting population is <strong>91 after excluding 2 forks</strong> (public 58 · private 33) (§A.3).</span></li>
+  <li><span class="lang-ko"><strong>커밋 집계 규칙 고정 — 기본(default) 브랜치 · 작성일(author date) 기준.</strong> 1분기 정의("브랜치 무관 커밋")는 브랜치 삭제·스쿼시 병합 시 발행 후 수치가 감소할 수 있어 공시 수치로 부적합합니다. 이번 분기부터 기본 브랜치 기준으로 고정하며, GitHub API로 누구나 공개 저장소 수치를 재현할 수 있습니다. 프로젝트 팀의 자체 집계(브랜치 포함)와는 차이가 있을 수 있으며, 본 리포트의 수치가 공시 기준입니다.</span><span class="lang-en"><strong>Counting rule fixed — default branch · author date.</strong> The Q1 definition ("branch-agnostic commits") is unsuitable for a disclosed figure because deleting a branch or squash-merging can reduce the number after publication. From this quarter the basis is fixed to the default branch, and anyone can reproduce the public-repository figures through the GitHub API. Project teams' own counts (including branches) may differ; the figures in this report are the disclosure basis.</span></li>
+  <li><span class="lang-ko"><strong>표기 수위 하향 — 비공개 저장소는 이름·개별 커밋 수를 표기하지 않습니다.</strong> 1분기 리포트는 비공개 저장소도 이름을 표기했으나, 저장소명이 미공개 프로젝트·거래 상대방·파일럿 현장을 식별시킬 수 있어 이번 분기부터 비공개 개발은 <strong>워크스트림 단위 집계</strong>로만 공개합니다. 총계와 워크스트림 소계는 변동 없이 그대로 공시되므로 집계의 완결성은 유지되며, 검증 앵커는 공개 서비스 URL(V2)과 공시 문서(V1)로 대체됩니다. 컨소시엄 관련 서술은 <strong>2026-04-21 공시 PDF가 적용한 익명화 수위를 초과하지 않습니다</strong>(§7.1).</span><span class="lang-en"><strong>Reduced disclosure detail — private repositories are not named and their individual commit counts are not shown.</strong> The Q1 report named private repositories too, but a repository name can identify an unannounced project, a counterparty or a pilot site, so from this quarter private development is disclosed only as <strong>workstream-level aggregates</strong>. Totals and workstream subtotals are disclosed unchanged, so the count remains complete, and the verification anchors become public service URLs (V2) and disclosure documents (V1). Descriptions relating to the consortium <strong>do not exceed the level of anonymisation applied in the 2026-04-21 disclosure PDF</strong> (§7.1).</span></li>
+</ol>
+<table>
+  <thead><tr><th><span class="lang-ko">용어</span><span class="lang-en">Term</span></th><th><span class="lang-ko">정의</span><span class="lang-en">Definition</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">추적 저장소</span><span class="lang-en">Tracked repositories</span></td><td><span class="lang-ko">저장소 <strong>재고</strong>는 3개 GitHub 네임스페이스 93개(공개 60 · 비공개 33, 2026-08-03 기준)이며, 커밋 집계 <strong>모집단</strong>은 포크 2개를 제외한 <strong>91개</strong>(공개 58 · 비공개 33)입니다. 이 중 Q2 커밋이 발생한 저장소는 45개입니다(§A.3).</span><span class="lang-en">The repository <strong>inventory</strong> is 93 across the three GitHub namespaces (public 60 · private 33, as of 2026-08-03), while the <strong>counting population</strong> is <strong>91</strong> after excluding 2 forks (public 58 · private 33). Of these, 45 recorded Q2 commits (§A.3).</span></td></tr>
+    <tr><td><span class="lang-ko">커밋 활성 저장소</span><span class="lang-en">Commit-active repositories</span></td><td><span class="lang-ko">2026-04-01 ~ 06-30에 기본 브랜치 커밋 ≥ 1건이 발생한 저장소.</span><span class="lang-en">Repositories with ≥ 1 default-branch commit between 2026-04-01 and 06-30.</span></td></tr>
+    <tr><td><span class="lang-ko">커밋</span><span class="lang-en">Commit</span></td><td><span class="lang-ko">기본 브랜치에 기록된 커밋 (작성일 기준, 병합 커밋 포함).</span><span class="lang-en">A commit recorded on the default branch (by author date, merge commits included).</span></td></tr>
+    <tr><td><span class="lang-ko">검증 등급</span><span class="lang-en">Verifiability tier</span></td><td><span class="lang-ko">V1 외부 검증 가능 · V2 서비스로 확인 가능 · V3 재단 내부 집계. §6.6 참조.</span><span class="lang-en">V1 traceable to public sources · V2 evidenced by a live service · V3 Foundation internal aggregation. See §6.6.</span></td></tr>
+  </tbody>
+</table>
+
+<h3 id="s6.2">6.2 <span class="lang-ko">커밋 활동 요약</span><span class="lang-en">Commit Activity Summary</span></h3>
+<div class="kpi">
+  <div class="cell"><div class="label">Commits (Q2)</div><div class="value">1,945</div><div class="unit"><span class="lang-ko">신규 집계 기준 · Q1(448)과 기준이 달라 증감 비교 불가</span><span class="lang-en">New counting basis · not comparable with Q1 (448) because the basis differs</span></div></div>
+  <div class="cell"><div class="label">Public / Private</div><div class="value">259 / 1,686</div><div class="unit"><span class="lang-ko">비공개 비중 86.7% <span class="vb v3">V3</span></span><span class="lang-en">86.7% private <span class="vb v3">V3</span></span></div></div>
+  <div class="cell"><div class="label">Commit-active Repos</div><div class="value">45</div><div class="unit"><span class="lang-ko">공개 17 · 비공개 28</span><span class="lang-en">public 17 · private 28</span></div></div>
+  <div class="cell"><div class="label">Top Track</div><div class="value">55.8%</div><div class="unit"><span class="lang-ko">디지털 트윈 (1,086 commits)</span><span class="lang-en">Digital twin (1,086 commits)</span></div></div>
+</div>
+
+<figure class="viz" aria-label="Q2 commit split">
+  <div class="vizscroll"><svg viewBox="0 0 900 300" role="img">
+    <text x="20" y="28" font-family="ui-monospace,Menlo,monospace" font-size="11" fill="#5b6068" letter-spacing="0.1em">Q2 COMMITS · PUBLIC vs PRIVATE</text>
+    <!-- stacked bar -->
+    <rect x="20" y="44" width="860" height="26" fill="#f1efe9" stroke="#e4e2dc"/>
+    <rect x="20" y="44" width="115" height="26" fill="#15665c"/>
+    <rect x="135" y="44" width="745" height="26" fill="#6a7a8d" opacity="0.55"/>
+    <text x="26" y="62" font-family="ui-monospace,Menlo,monospace" font-size="11" fill="#fff">259</text>
+    <text x="500" y="62" font-family="ui-monospace,Menlo,monospace" font-size="11" fill="#fff" text-anchor="middle">private 1,686 (86.7%)</text>
+    <!-- workstream horizontal bars, scale: 1,086 = 560px -->
+    <g font-family="ui-monospace,Menlo,monospace" font-size="11">
+      <text x="20" y="106" fill="#5b6068" letter-spacing="0.1em">TOP WORKSTREAMS</text>
+      <g transform="translate(230,118)">
+        <text x="-10" y="11" text-anchor="end" fill="#2e3238">Physical AI · DT</text>
+        <rect x="0" y="0" width="560" height="14" fill="#0d4a43"/><text x="566" y="11" fill="#5b6068">1,086</text>
+        <text x="-10" y="35" text-anchor="end" fill="#2e3238">Holder infrastructure</text>
+        <rect x="0" y="24" width="166" height="14" fill="#4a5b52"/><text x="172" y="35" fill="#5b6068">322</text>
+        <text x="-10" y="59" text-anchor="end" fill="#2e3238">AI media · city</text>
+        <rect x="0" y="48" width="134" height="14" fill="#8a5e3c"/><text x="140" y="59" fill="#5b6068">259</text>
+        <text x="-10" y="83" text-anchor="end" fill="#2e3238">Agent systems</text>
+        <rect x="0" y="72" width="80" height="14" fill="#c68f2a"/><text x="85" y="83" fill="#5b6068">155 · public</text>
+        <text x="-10" y="107" text-anchor="end" fill="#2e3238">Other experiments</text>
+        <rect x="0" y="96" width="34" height="14" fill="#6a7a8d"/><text x="40" y="107" fill="#5b6068">65</text>
+        <text x="-10" y="131" text-anchor="end" fill="#2e3238">Disclosure · ops</text>
+        <rect x="0" y="120" width="30" height="14" fill="#6a7a8d"/><text x="36" y="131" fill="#5b6068">58</text>
+      </g>
+    </g>
+  </svg></div>
+  <figcaption>Figure 6.2 · <span class="lang-ko">분기 커밋의 공개/비공개 분해(상단)와 워크스트림별 분포(하단). <strong>상단 막대</strong>는 공개/비공개를 나타냅니다 — 녹색 = 공개 259 · 회청색 = 비공개 1,686. <strong>하단 막대</strong>의 색은 <strong>워크스트림 구분용</strong>이며 공개/비공개를 뜻하지 않습니다 — 짙은 녹색 = 디지털 트윈, 청록 = 홀더 참여 인프라, 갈색 = AI 미디어·시티, 금색 = 에이전트 시스템, 회청색 = 기타 실험·공시/운영. 상단과 하단에 같은 회청색이 쓰이지만 의미는 서로 다릅니다. 워크스트림별 공개/비공개 구성은 Figure 6.3을 참조하십시오.</span><span class="lang-en">Public/private split of the quarter's commits (top) and distribution by workstream (bottom). <strong>The top bar</strong> shows public versus private — green = public 259 · slate = private 1,686. <strong>The colours in the bottom bars</strong> are <strong>workstream identifiers</strong> and do not encode public/private — dark green = digital twin, teal = holder participation infrastructure, brown = AI media · city, gold = agent systems, slate = other experiments and disclosure/operations. The same slate appears in both rows but means different things. For the public/private composition of each workstream, see Figure 6.3.</span></figcaption>
+</figure>
+
+<h3 id="s6.3">6.3 <span class="lang-ko">테마별 분류</span><span class="lang-en">Thematic Classification</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">집계 구분</span><span class="lang-en">Aggregation group</span></th><th>Commits</th><th><span class="lang-ko">비중</span><span class="lang-en">Share</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">비-컨소시엄 워크스트림</span><span class="lang-en">Non-consortium workstream</span></td><td>859</td><td>44.2%</td></tr>
+    <tr><td><span class="lang-ko">컨소시엄 기술축 연계 워크스트림</span><span class="lang-en">Workstream aligned with the consortium's technical track</span></td><td>1,086</td><td>55.8%</td></tr>
+    <tr><td><strong><span class="lang-ko">모스랜드 관리 네임스페이스 추적 활동 합계</span><span class="lang-en">Total activity tracked across Mossland-administered namespaces</span></strong></td><td><strong>1,945</strong></td><td>100%</td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko">위 수치는 <strong>모스랜드가 관리하는 GitHub 네임스페이스에서 관찰된 활동량</strong>이며, 해당 커밋은 모스랜드 GitHub 조직 구성원 계정으로 작성되었습니다. <strong>본 리포트는 작성자의 고용 법인, 개발비 부담 주체, 성과물·지식재산의 권리 귀속을 확정하지 않습니다</strong> — 이는 고용·용역 계약과 컨소시엄 협약이 정하는 사항입니다(§7.1).</p><p class="small lang-en">The figures above are <strong>activity observed in the GitHub namespaces Mossland administers</strong>, and those commits were authored from accounts that are members of the Mossland GitHub organisations. <strong>This report does not establish the authors' employing entity, which party bore the development cost, or where rights in the output and intellectual property reside</strong> — those are matters for the employment and service contracts and for the consortium agreement (§7.1).</p>
+<p class="small lang-ko"><strong>시점 고지</strong> — 컨소시엄 기술축 연계 워크스트림 1,086건은 저자일 기준 2026-04-01~06-30에 기록된 활동으로, <strong>과제 협약 체결(2026-07-10) 이전</strong>입니다. 따라서 <strong>정부과제 수행 실적도, 과제비 집행 실적도 아닙니다.</strong> &ldquo;컨소시엄 기술축 연계&rdquo;는 기술 주제가 컨소시엄 과제와 같은 축에 있다는 뜻이며, 과제 수행을 의미하지 않습니다.</p><p class="small lang-en"><strong>Timing note</strong> — the 1,086 commits in the workstream aligned with the consortium's technical track were recorded, on an author-date basis, between 2026-04-01 and 06-30, <strong>before the project agreement was executed (2026-07-10)</strong>. They are therefore <strong>neither performance under the government project nor expenditure of project funds.</strong> "Aligned with the consortium's technical track" means the technical subject matter sits on the same axis as the consortium project; it does not mean the project was being performed.</p>
+<p class="small lang-ko"><strong>커밋 수가 의미하지 않는 것</strong> — 위 1,086건은 <strong>재단의 자산 보유, 재단의 지식재산 귀속, 재단의 비용 집행 규모, 매출 또는 수익</strong> 중 어느 것도 의미하지 않습니다. 개발 활동량의 지표일 뿐이며, 커밋 1건의 크기도 일정하지 않습니다. 본 구분은 이 오독을 막기 위해 이번 분기부터 신설했습니다.</p><p class="small lang-en"><strong>What the commit count does not mean</strong> — the 1,086 commits above signify <strong>none of the following: assets held by the Foundation, intellectual property vesting in the Foundation, the scale of the Foundation's spending, or revenue or profit</strong>. They are an indicator of development activity only, and a single commit is not of uniform size. This distinction was introduced this quarter precisely to prevent that misreading.</p>
+
+<table>
+  <thead><tr><th><span class="lang-ko">테마</span><span class="lang-en">Theme</span></th><th>Commits</th><th><span class="lang-ko">비중</span><span class="lang-en">Share</span></th><th><span class="lang-ko">공개 / 비공개</span><span class="lang-en">Public / private</span></th><th><span class="lang-ko">대표 결과물 · 검증 앵커</span><span class="lang-en">Representative output · verification anchor</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">Physical AI · 디지털 트윈</span><span class="lang-en">Physical AI · digital twin</span></td><td><strong>1,086</strong></td><td>55.8%</td><td>0 / 1,086</td><td><span class="lang-ko">비공개 2개 저장소 <span class="lock">🔒</span> — 앵커: 4/21 컨소시엄 참여 공시</span><span class="lang-en">2 private repositories <span class="lock">🔒</span> — anchor: the 4/21 consortium participation disclosure</span></td></tr>
+    <tr><td><span class="lang-ko">홀더 참여 인프라</span><span class="lang-en">Holder participation infrastructure</span></td><td>322</td><td>16.6%</td><td>23 / 299</td><td><span class="lang-ko">비공개 저장소 <span class="lock">🔒</span> — 앵커: passport · agora · wa.moss.land</span><span class="lang-en">private repository <span class="lock">🔒</span> — anchors: passport · agora · wa.moss.land</span> · <a href="https://github.com/MosslandOpenDevs/links" target="_blank" rel="noopener">links</a></td></tr>
+    <tr><td><span class="lang-ko">AI 미디어 · 시티</span><span class="lang-en">AI media · city</span></td><td>259</td><td>13.3%</td><td>41 / 218</td><td><a href="https://github.com/MosslandOpenDevs/alpha" target="_blank" rel="noopener">alpha</a> · <span class="lang-ko">비공개 5개 저장소 <span class="lock">🔒</span> — 앵커: signalmap · npc · city · media · recipe.moss.land</span><span class="lang-en">5 private repositories <span class="lock">🔒</span> — anchors: signalmap · npc · city · media · recipe.moss.land</span></td></tr>
+    <tr><td><span class="lang-ko">에이전트 시스템</span><span class="lang-en">Agent systems</span></td><td>155</td><td>8.0%</td><td>155 / 0</td><td><a href="https://github.com/MosslandOpenDevs/agentic-orchestrator" target="_blank" rel="noopener">agentic-orchestrator</a> · <a href="https://github.com/MosslandOpenDevs/Algora" target="_blank" rel="noopener">Algora</a> · <a href="https://github.com/MosslandOpenDevs/bridge-2026" target="_blank" rel="noopener">bridge-2026</a></td></tr>
+    <tr><td><span class="lang-ko">공시 · 운영 · 문서</span><span class="lang-en">Disclosure · operations · documentation</span></td><td>58</td><td>3.0%</td><td>40 / 18</td><td><a href="https://github.com/mossland/Disclosure-and-Materials" target="_blank" rel="noopener">Disclosure-and-Materials</a> · <a href="https://github.com/mossland/Projects" target="_blank" rel="noopener">Projects</a> · <span class="lang-ko">비공개 저장소 <span class="lock">🔒</span> 외</span><span class="lang-en">and a private repository <span class="lock">🔒</span></span></td></tr>
+    <tr><td><span class="lang-ko">기타 실험 (미공개 단계)</span><span class="lang-en">Other experiments (pre-announcement)</span></td><td>65</td><td>3.3%</td><td>0 / 65</td><td><span class="lang-ko">비공개 실험 저장소 13개 — 공개 실체(서비스·공시·블로그)가 생기는 시점에 명명 공개</span><span class="lang-en">13 private experimental repositories — named publicly once a public artefact (service, disclosure or blog post) exists</span></td></tr>
+    <tr><td><strong>Total</strong></td><td><strong>1,945</strong></td><td>100%</td><td>259 / 1,686</td><td>—</td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><strong>비공개 저장소는 저장소명·개별 커밋 수를 표기하지 않습니다.</strong> 저장소명 자체가 미공개 프로젝트·거래 상대방·현장을 식별시킬 수 있어, 본 리포트는 비공개 개발을 <strong>워크스트림 단위 집계</strong>로만 공개하고 개별 저장소 단위로는 공개하지 않습니다. 해당 작업의 검증 앵커는 결과물이 공개된 서비스 URL(V2) 또는 공시 문서(V1)입니다. 이 원칙은 1분기 대비 표기 수위를 낮춘 변경이며, 총계·워크스트림 소계는 그대로 유지되어 집계의 완결성은 영향받지 않습니다.</p><p class="small lang-en"><strong>Private repositories are not named, and their individual commit counts are not stated.</strong> A repository name alone can identify an unannounced project, a counterparty or a site, so this report discloses private development <strong>only as workstream-level aggregates</strong>, never per repository. The verification anchor for that work is the service URL where the output is public (V2) or a disclosure document (V1). This principle lowers the level of detail relative to Q1; totals and workstream subtotals are unchanged, so the completeness of the count is unaffected.</p>
+
+<figure class="viz" aria-label="Q2 commits by theme, public versus private">
+  <div class="vizscroll"><svg viewBox="0 0 900 280" role="img" aria-label="Q2 commits by theme, public vs private">
+<text x="40" y="24" font-family="Georgia,serif" font-size="13" fill="#111418" font-weight="bold">테마별 커밋 — 공개 / 비공개 구성 <tspan font-family="ui-monospace,Menlo,monospace" font-size="10" font-weight="normal" fill="#5b6068">(총 1,945)</tspan></text>
+<text x="200" y="59" text-anchor="end" font-family="Georgia,serif" font-size="11.5" fill="#111418">Physical AI · 디지털 트윈</text>
+<rect x="210.0" y="46" width="452.0" height="17" fill="#cecac1"/>
+<text x="670.0" y="59" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">1,086 <tspan fill="#15665c">공개 0</tspan> · 비공개 1086</text>
+<text x="200" y="89" text-anchor="end" font-family="Georgia,serif" font-size="11.5" fill="#111418">홀더 참여 인프라</text>
+<rect x="210" y="76" width="9.6" height="17" fill="#15665c"/>
+<rect x="219.6" y="76" width="124.4" height="17" fill="#cecac1"/>
+<text x="352.0" y="89" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">322 <tspan fill="#15665c">공개 23</tspan> · 비공개 299</text>
+<text x="200" y="119" text-anchor="end" font-family="Georgia,serif" font-size="11.5" fill="#111418">AI 미디어 · 시티</text>
+<rect x="210" y="106" width="17.1" height="17" fill="#15665c"/>
+<rect x="227.1" y="106" width="90.7" height="17" fill="#cecac1"/>
+<text x="325.8" y="119" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">259 <tspan fill="#15665c">공개 41</tspan> · 비공개 218</text>
+<text x="200" y="149" text-anchor="end" font-family="Georgia,serif" font-size="11.5" fill="#111418">에이전트 시스템</text>
+<rect x="210" y="136" width="64.5" height="17" fill="#15665c"/>
+<text x="282.1" y="149" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">155 <tspan fill="#15665c">공개 155</tspan> · 비공개 0</text>
+<text x="200" y="179" text-anchor="end" font-family="Georgia,serif" font-size="11.5" fill="#111418">기타 실험 (미공개 단계)</text>
+<rect x="210.0" y="166" width="27.1" height="17" fill="#cecac1"/>
+<text x="245.1" y="179" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">65 <tspan fill="#15665c">공개 0</tspan> · 비공개 65</text>
+<text x="200" y="209" text-anchor="end" font-family="Georgia,serif" font-size="11.5" fill="#111418">공시 · 운영 · 문서</text>
+<rect x="210" y="196" width="16.6" height="17" fill="#15665c"/>
+<rect x="226.6" y="196" width="7.5" height="17" fill="#cecac1"/>
+<text x="242.1" y="209" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">58 <tspan fill="#15665c">공개 40</tspan> · 비공개 18</text>
+<g font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">
+<rect x="210" y="239" width="14" height="11" fill="#15665c"/><text x="230" y="248">공개 저장소 259 (13.3%)</text>
+<rect x="400" y="239" width="14" height="11" fill="#cecac1"/><text x="420" y="248">비공개 저장소 1,686 (86.7%) — 🔒 · 등급 V3</text>
+</g></svg></div>
+  <figcaption>Figure 6.3 · <span class="lang-ko">테마별 커밋의 공개/비공개 구성. 막대 길이는 커밋 수이며, 진한 구간이 공개 저장소입니다. 비공개 저장소는 개별 커밋 수를 표기하지 않고 테마 합계로만 공시합니다(§6.6 🔒 표기).</span><span class="lang-en">Public/private composition of commits by theme. Bar length is the commit count, and the darker segment is the public repositories. Private repositories are disclosed only as theme totals, without individual commit counts (see the 🔒 convention in §6.6).</span></figcaption>
+</figure>
+
+<h3 id="s6.4">6.4 <span class="lang-ko">월별 진행 — 디지털 트윈 트랙</span><span class="lang-en">Monthly Progression — DT Track</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">워크스트림</span><span class="lang-en">Workstream</span></th><th><span class="lang-ko">4월</span><span class="lang-en">April</span></th><th><span class="lang-ko">5월</span><span class="lang-en">May</span></th><th><span class="lang-ko">6월</span><span class="lang-en">June</span></th><th><span class="lang-ko">계</span><span class="lang-en">Total</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">Physical AI · 디지털 트윈 (비공개 <span class="lock">🔒</span>)</span><span class="lang-en">Physical AI · digital twin (private <span class="lock">🔒</span>)</span></td><td>455</td><td>324</td><td>307</td><td><strong>1,086</strong></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko">분기 내내 지속 개발된 유일한 트랙입니다. 나머지 테마는 특정 구간 집중형(AI 미디어: 5월 초·중순, 참여 인프라: 6월 하순)의 패턴을 보입니다. 두 저장소에는 <strong>트랙 개시 이전 이력</strong>(저자일 2026-02-12~03-31 기준 512건)이 함께 존재하나, 본 리포트의 집계 규칙(저자일 기준 · §A.2)에 따라 <strong>Q2 집계에서 전량 제외</strong>되어 있습니다 — 위 1,086건은 모두 <strong>분기 내 저자일 커밋</strong>이며, 분기 구간에서 저자일과 커미터일이 7일을 초과해 벌어지는 이력 이관 흔적은 확인되지 않았습니다. 4월분도 특정 일자 일괄 유입이 아니라 월 전체에 분산되어 있습니다(최다 일자 34건). 다만 커밋 1건의 크기는 일정하지 않으므로, 월별 값은 작업량의 절대 비교가 아니라 추세 지표로 읽어야 합니다. 본 수치는 비공개 저장소라 외부 재현은 불가하나, 저장소 접근 권한이 있으면 §A.2의 규칙으로 동일하게 재현됩니다. <span class="vb v3">V3</span></p><p class="small lang-en">The only track developed continuously throughout the quarter. The remaining themes show a burst pattern concentrated in particular stretches (AI media: early and mid-May; participation infrastructure: late June). The two repositories also hold <strong>history predating the start of the track</strong> (512 commits with author dates from 2026-02-12 to 03-31), but under this report's counting rule (author date · §A.2) <strong>all of it is excluded from the Q2 count</strong> — the 1,086 above are all <strong>commits authored within the quarter</strong>, and within the quarter no trace of history import, in the sense of author and committer dates diverging by more than seven days, was found. April's share is spread across the whole month rather than arriving in a single-day bulk load (busiest day: 34). A single commit is not of uniform size, however, so monthly values should be read as a trend indicator rather than an absolute comparison of effort. These figures come from private repositories and cannot be reproduced externally, but they reproduce identically under the §A.2 rules for anyone with repository access. <span class="vb v3">V3</span></p>
+
+<h3 id="s6.5">6.5 <span class="lang-ko">워크스트림 하이라이트</span><span class="lang-en">Workstream Highlights</span></h3>
+
+<h4><span class="lang-ko">Physical AI · 디지털 트윈</span><span class="lang-en">Physical AI · digital twin</span> · 1,086 commits <span class="lock">🔒 <span class="lang-ko">비공개</span><span class="lang-en">private</span></span> <span class="vb v3">V3</span></h4>
+<p class="lang-ko">추적 GitHub 활동에서 가장 많은 커밋이 기록된 기술축(55.8%)으로, 국토교통부 AX Sprint 컨소시엄 과제와 같은 기술축의 선행 활동입니다(§7.1). 본 리포트는 <strong>2026-04-21 공시가 적용한 익명화 수위를 넘지 않는 것</strong>을 표기 원칙으로 삼아, 컨소시엄 주관기관·제품의 명칭과 기능 사양은 기술하지 않습니다. 본 트랙의 커밋은 전량 모스랜드 GitHub 조직 구성원 계정으로 작성되었으며(고용 법인·비용 부담·지식재산 귀속은 본 리포트가 확정하지 않습니다 — §6.3), 해당 워크스트림에서 <strong>관찰된 작업</strong>의 성격은 두 계층으로 구분됩니다 — 건물 모델을 웹에서 구동하기 위한 <strong>변환·렌더링 계층</strong>(대용량 모델의 로딩·렌더 효율, 대규모 씬의 프레임 안정성)과, 실제 건물의 운영 신호를 다루는 <strong>운영 계층</strong>(영상 탐지 스트림, IoT 디바이스 매핑, 재실 신호, 모니터링 화면). 두 계층이 분기 중 연동되어 하나의 트랙으로 진행되었습니다. 현실 신호가 트윈으로 들어오기 시작한 이 트랙이 분기 아이덴티티 "Reality Enters the Loop"의 실체입니다.</p><p class="lang-en">The technical track with the most recorded commits in tracked GitHub activity (55.8%), and prior activity on the same technical track as the MOLIT AX Sprint consortium project (§7.1). This report takes as its rule <strong>not to exceed the level of anonymisation applied in the 2026-04-21 disclosure</strong>, so it does not describe the names of the consortium lead or its products, nor their functional specifications. All commits in this track were authored from accounts belonging to Mossland GitHub organisation members (this report does not determine the employing entity, who bore the cost, or ownership of intellectual property — §6.3), and the <strong>observed work</strong> in this workstream falls into two layers — a <strong>conversion and rendering layer</strong> for running building models in a browser (load and render efficiency for large models, frame stability in large scenes), and an <strong>operations layer</strong> handling a real building's operational signals (video detection streams, IoT device mapping, occupancy signals, monitoring screens). The two layers were connected during the quarter and proceeded as a single track. This track — where real-world signals began entering the twin — is the substance behind the quarter's identity, "Reality Enters the Loop".</p>
+
+<h4><span class="lang-ko">홀더 참여 인프라 — Passport</span><span class="lang-en">Holder participation infrastructure — Passport</span> <span class="lock">🔒 <span class="lang-ko">비공개</span><span class="lang-en">private</span></span> → <a href="https://passport.moss.land" target="_blank" rel="noopener">passport.moss.land</a> <span class="vb v2">V2</span></h4>
+<p class="lang-ko">6/9 개발 착수, 6/10 첫 배포, 6/30 오픈베타 — 3주간 v1.0에서 v1.6까지 도달했습니다. 상세는 §7.2.</p><p class="lang-en">Development started 6/9, first deployment 6/10, open beta 6/30 — reaching v1.6 from v1.0 in three weeks. Details in §7.2.</p>
+
+<h4><a href="https://github.com/MosslandOpenDevs/agentic-orchestrator" target="_blank" rel="noopener">agentic-orchestrator</a> · 113 commits <span class="vb v1">V1</span></h4>
+<p class="lang-ko">6월 하순 안정화 집중 — DB 유실 대비 복원력(v0.6.10: 스키마 자가 복구·롤링 백업·상태 열화 표시), 코드 생성 검증 게이트(v0.6.9), CI 정상화, 접근성·보안 일괄 정비. 상세는 §7.4.</p><p class="lang-en">Late June concentrated on stabilisation — resilience against database loss (v0.6.10: schema self-healing, rolling backups, degraded-state reporting), a code-generation verification gate (v0.6.9), CI restored, and a sweep of accessibility and security work. Details in §7.4.</p>
+
+<h4><span class="lang-ko">AI 미디어 · 시티</span><span class="lang-en">AI media · city</span> <span class="lock">🔒 <span class="lang-ko">비공개</span><span class="lang-en">private</span></span> — <span class="lang-ko">5월 집중 스프린트</span><span class="lang-en">Concentrated sprint in May</span></h4>
+<p class="lang-ko">AI 미디어 클러스터의 대표 두 서비스입니다. NPC는 2주간 페르소나 15종 추가·주간 칼럼·측정 대시보드를, Signal Map은 수집 크론 체계(일간 무료·주간 LLM 분리)·정규화 파이프라인을 구축한 뒤, 5월 하순부터 자동 파이프라인 운영 체제로 전환했습니다. 상세는 §7.5.</p><p class="lang-en">The two headline services of the AI media cluster. Over two weeks NPC added 15 personas, a weekly column and a measurement dashboard, while Signal Map built its collection cron structure (daily free and weekly LLM runs kept separate) and its normalisation pipeline; from late May both moved to automated pipeline operation. Details in §7.5.</p>
+
+<h3 id="s6.6">6.6 <span class="lang-ko">검증 가능성 등급 (V1 · V2 · V3)</span><span class="lang-en">Verifiability Tiers</span></h3>
+<p class="lang-ko">1분기 리포트는 "누구나 검증 가능한 신호"를 오픈소스 운영의 신뢰 근거로 삼았습니다. 2분기는 개발의 86.7%가 비공개 저장소에서 발생해, 같은 프레임을 그대로 쓸 수 없습니다. 이번 분기부터 <strong>주요 공시 KPI</strong>에 검증 가능성 등급을 부여해, <strong>무엇이 외부에서 검증되고 무엇이 재단의 주장인지</strong>를 리포트 스스로 구분합니다.</p><p class="lang-en">The Q1 report treated "signals anyone can verify" as the trust basis for open-source operation. In Q2, 86.7% of development happened in private repositories, so that frame cannot be carried over unchanged. From this quarter a verifiability tier is assigned to the <strong>principal disclosure KPIs</strong>, so that the report itself distinguishes <strong>what is externally verified from what is the Foundation's own assertion</strong>.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">등급</span><span class="lang-en">Tier</span></th><th><span class="lang-ko">의미</span><span class="lang-en">Meaning</span></th><th><span class="lang-ko">검증 방법</span><span class="lang-en">How it is verified</span></th><th><span class="lang-ko">예시</span><span class="lang-en">Examples</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="vb v1">V1</span></td><td><span class="lang-ko">공개 출처로 추적 가능</span><span class="lang-en">Traceable to public sources</span></td><td><span class="lang-ko">공개 저장소·온체인·공시 원문·제3자 데이터로 누구나 확인. 다만 <strong>재단이 발행한 공시 원문</strong>은 문서의 존재와 기재 내용이 확인된다는 뜻이며, 그 진술이 제3자에 의해 독립 검증되었다는 뜻은 아닙니다.</span><span class="lang-en">Anyone can check it against public repositories, on-chain records, the text of a disclosure, or third-party data. Note, however, that for <strong>a disclosure issued by the Foundation</strong> this means the document's existence and contents can be confirmed — not that its statements have been independently verified by a third party.</span></td><td><span class="lang-ko">공개 커밋 259 · 공시 2건 · 블로그 19건 · 유통계획 상한</span><span class="lang-en">259 public commits · 2 disclosures · 19 blog posts · supply-plan ceiling</span></td></tr>
+    <tr><td><span class="vb v2">V2</span></td><td><span class="lang-ko">서비스로 확인 가능</span><span class="lang-en">Evidenced by a live service</span></td><td><span class="lang-ko">저장소는 비공개지만 결과물이 라이브 서비스로 접근 가능. 서비스는 <strong>산출물의 존재를 보조적으로 확인</strong>할 뿐, 커밋 수·작성 주체·비용 귀속을 검증하지는 않습니다(그 수치는 V3).</span><span class="lang-en">The repository is private but the output is reachable as a live service. A service <strong>corroborates that an output exists</strong>; it does not verify the commit count, who authored it, or who bore the cost (those figures are V3).</span></td><td><span class="lang-ko">Passport 기능 · Agora 변경 · AI 미디어 서비스</span><span class="lang-en">Passport features · Agora changes · AI media services</span></td></tr>
+    <tr><td><span class="vb v3">V3</span></td><td><span class="lang-ko">재단 내부 집계</span><span class="lang-en">Foundation internal aggregation</span></td><td><span class="lang-ko">외부 재현 불가 — 집계 방법을 §A에 명시하고 재단이 책임</span><span class="lang-en">Not externally reproducible — the method is set out in §A and the Foundation takes responsibility for it</span></td><td><span class="lang-ko">비공개 커밋 1,686 · 월별 분해</span><span class="lang-en">1,686 private commits · monthly breakdown</span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><strong>🔒 표기</strong> — 본 리포트에서 서비스·트랙 이름 옆의 🔒는 <strong>저장소가 비공개</strong>임을 뜻하며, 이 경우 §6.3의 표기 원칙에 따라 <strong>개별 저장소의 커밋 수를 표기하지 않고</strong> 묶음 합계로만 공시합니다(예: §7.5 AI 미디어 클러스터 259 = 공개 41 · 비공개 218). 🔒는 서비스의 공개 여부가 아니라 <em>저장소</em>의 공개 여부를 가리키며, 비공개 저장소의 결과물이 공개 서비스로 접근 가능한 경우는 V2로 표기합니다.</p><p class="small lang-en"><strong>The 🔒 marker</strong> — in this report, 🔒 next to a service or track name means <strong>the repository is private</strong>, in which case, under the notation principle in §6.3, <strong>individual repository commit counts are not stated</strong> and only the grouped total is disclosed (for example §7.5, AI media cluster 259 = 41 public · 218 private). 🔒 refers to whether the <em>repository</em> is public, not whether the service is; where the output of a private repository is reachable as a public service, it is marked V2.</p>
+
+<!-- ================= §7 ================= -->
+<h2 class="section" id="s7"><span class="num">§7</span><span class="lang-ko">핵심 프로젝트 심층</span><span class="lang-en">Core Projects</span></h2>
+
+<h3 id="s7.1">7.1 <span class="lang-ko">디지털 트윈 트랙 · AX Sprint R&amp;D 컨소시엄 (2026-06-25 선정)</span><span class="lang-en">Digital Twin Track &amp; AX Sprint Consortium (Selected 2026-06-25)</span></h3>
+
+<h4><span class="lang-ko">컨소시엄 참여 공시 요지 (2026-04-21 · MOSS-DISC-2026-0421)</span><span class="lang-en">Summary of the consortium participation disclosure (2026-04-21 · MOSS-DISC-2026-0421)</span></h4>
+<p class="lang-ko">재단은 국토교통부 「AI응용제품 신속상용화 지원사업(국토·교통)」 Type 2 Build-up 트랙에 참여하는 R&amp;D 컨소시엄에 <strong>공동연구·국제표준화 협력기관</strong>으로 참여함을 공시했습니다. 본 공시는 <strong>컨소시엄 구성·신청(제안) 단계</strong>에 관한 것으로, 공시 자체가 정부의 과제 선정 또는 집행에 관한 사항이 아님을 명시했고, 구체적 진행 사항은 공식 채널로 별도 안내한다고 밝혔습니다.</p><p class="lang-en">The Foundation disclosed its participation as a <strong>joint-research and international-standardisation cooperating institution</strong> in an R&amp;D consortium applying to the Type 2 Build-up track of MOLIT's "Rapid Commercialisation Support Programme for AI-Applied Products (Land &amp; Transport)". That disclosure concerned the <strong>consortium formation and application (proposal) stage</strong>; it stated explicitly that the disclosure itself did not concern the government's selection or execution of the project, and that specific progress would be announced separately via official channels.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">항목</span><span class="lang-en">Item</span></th><th><span class="lang-ko">내용</span><span class="lang-en">Detail</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">협력 주제</span><span class="lang-en">Subject of cooperation</span></td><td><span class="lang-ko">AI·디지털 트윈 기반 건물 에너지 솔루션의 파일럿 및 사업화를 위한 R&amp;D 컨소시엄 협력</span><span class="lang-en">R&amp;D consortium cooperation on piloting and commercialising an AI and digital-twin based building energy solution</span></td></tr>
+    <tr><td><span class="lang-ko">구성</span><span class="lang-en">Composition</span></td><td><span class="lang-ko">주관 — 국내 SW·디지털 트윈 기업 / 참여 — 성균관대 산학협력단, 국내 엔지니어링 기업</span><span class="lang-en">Lead — a domestic SW and digital twin company / Participants — the SKKU Industry-Academic Cooperation Foundation and a domestic engineering company</span></td></tr>
+    <tr><td><span class="lang-ko">수요기업 (LOI)</span><span class="lang-en">Demand companies (LOI)</span></td><td><span class="lang-ko">국내 "S"사(글로벌 전자, 4/17) · Flakt Group(독일 헤르네, 4/16) · 오션엔지니어링(4/17) — LOI는 법적 구속력 없는 관심 표명이며, <strong>위 명칭은 컨소시엄 사업계획서·LOI에 기반한 것으로 재단과 제3자 간 직접 거래·협약 관계를 의미하지 않습니다</strong>(MOSS-DISC-2026-0421 제6항 4)</span><span class="lang-en">Domestic "S" (global electronics, 4/17) · Flakt Group (Herne, Germany, 4/16) · Ocean Engineering (4/17) — an LOI is a non-binding expression of interest, and <strong>the names above are based on the consortium business plan and the LOIs; they do not signify any direct dealing or agreement between the Foundation and those third parties</strong> (MOSS-DISC-2026-0421 §6-4)</span></td></tr>
+    <tr><td><span class="lang-ko">파일럿 사이트</span><span class="lang-en">Pilot sites</span></td><td><span class="lang-ko">국내 — 성균관대 자연과학캠퍼스 산학협력센터(수원, 19,669㎡ · EHP 32+341대 · NGSI-LD 기반) / 해외 — Spire Tower(폴란드 바르샤바, 49F · 220m · EU EPBD 적용)</span><span class="lang-en">Domestic — SKKU Natural Sciences Campus Industry-Academic Cooperation Building (Suwon, 19,669㎡ · 32+341 EHP units · NGSI-LD based) / Overseas — Spire Tower (Warsaw, Poland, 49F · 220m · subject to the EU EPBD)</span></td></tr>
+    <tr><td><span class="lang-ko">모스랜드 역할</span><span class="lang-en">Mossland's role</span></td><td><span class="lang-ko"><strong>공동연구·국제표준화 협력기관 (주관기관 아님)</strong> — (1) Physical AI·자율 거버넌스 공동연구 — 센서 데이터 신뢰성·검증, AI 에이전트 의사결정 감사가능성 (2) IEEE 2888 워킹그룹 국제표준 공동 기여, 오픈데이터·오픈소스 생태계 공동 참여</span><span class="lang-en"><strong>Joint-research and international-standardisation cooperating institution (not the lead institution)</strong> — (1) Joint research on Physical AI and autonomous governance — sensor data reliability and verification, auditability of AI agent decision-making (2) Co-contribution to IEEE 2888 Working Group international standards and joint participation in the open-data and open-source ecosystem</span></td></tr>
+    <tr><td><span class="lang-ko">글로벌 로드맵<sup>4</sup></span><span class="lang-en">Global roadmap<sup>4</sup></span></td><td><span class="lang-ko">Phase 1(2027) 폴란드·EU — Spire Tower 전개 → Phase 2(2028~29) 독일·네덜란드 EU 확장 → Phase 3(2030+) 영국·유럽 Renovation Wave</span><span class="lang-en">Phase 1 (2027) Poland · EU — Spire Tower deployment → Phase 2 (2028–29) expansion into Germany and the Netherlands → Phase 3 (2030+) UK and the European Renovation Wave</span></td></tr>
+    <tr><td><span class="lang-ko">계약 형태</span><span class="lang-en">Form of the arrangement</span></td><td><span class="lang-ko"><strong>비보상형·비지분형(non-compensatory, non-equity)</strong> — 정부 보조금·매칭펀드의 재단 이전 없음. 본 공시는 재단 수익 또는 MOC 시장 가치에 대한 직접적 인과를 시사하지 않음</span><span class="lang-en"><strong>Non-compensatory, non-equity</strong> — no transfer of government grants or matching funds to the Foundation. This disclosure implies no direct causal link to the Foundation's revenue or to the market value of MOC</span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><sup>4</sup> 로드맵은 컨소시엄 사업계획 기준이며, 정부 과제 선정·수행 결과에 따라 변경될 수 있습니다. 원문: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-04-21_ax-sprint-consortium-participation.pdf" target="_blank" rel="noopener">공시 PDF (KO)</a> · <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-04-21_ax-sprint-consortium-participation_en.pdf" target="_blank" rel="noopener">EN</a> <span class="vb v1">V1</span></p><p class="small lang-en"><sup>4</sup> The roadmap follows the consortium business plan and may change with the outcome of government project selection and performance. Originals: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-04-21_ax-sprint-consortium-participation.pdf" target="_blank" rel="noopener">Disclosure PDF (KO)</a> · <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-04-21_ax-sprint-consortium-participation_en.pdf" target="_blank" rel="noopener">EN</a> <span class="vb v1">V1</span></p>
+
+<h4><span class="lang-ko">선정 결과 (2026-06-25) · 협약 체결 (2026-07-10) 및 후속 공시</span><span class="lang-en">Selection result (2026-06-25) · agreement executed (2026-07-10) and the follow-up disclosure</span></h4>
+<p class="lang-ko">2026-06-25 국토교통부는 AX Sprint 사업 중 <strong>국토교통부 소관 공모</strong>의 최종 선정 결과로 <strong>총 26개 과제</strong>(국토·교통 분야 14개 · 도로·모빌리티 분야 12개)를 발표했고, 재단이 참여한 컨소시엄의 과제가 여기에 포함되었습니다. 해당 과제는 <strong>국토·교통 분야 Type 2 Build-up 트랙</strong>에 속합니다. 국토교통부가 밝힌 대로 선정 과제는 협약 체결을 거쳐 착수하며, 본 과제의 <strong>협약은 2026-07-10 체결</strong>되었습니다(§12). <span class="vb v1">V1</span></p><p class="lang-en">On 2026-06-25 MOLIT announced the final selection results for <strong>its own call within the AX Sprint programme</strong> — <strong>26 projects in total</strong> (14 in Land &amp; Transport, 12 in Road &amp; Mobility) — including the project of the consortium in which the Foundation participates. That project sits in the <strong>Land &amp; Transport field, Type 2 Build-up track</strong>. As MOLIT stated, selected projects commence following execution of an agreement, and the <strong>agreement for this project was executed on 2026-07-10</strong> (§12). <span class="vb v1">V1</span></p>
+<p class="lang-ko"><strong>선정·협약에도 불구하고 4/21 공시가 명시한 비보상형·비지분형 조건은 변경되지 않았습니다.</strong> 정부 지원금·매칭펀드는 재단으로 이전되지 않으며, 재단의 역할은 4/21 공시와 동일하게 공동 R&amp;D·국제표준화 협력에 한정됩니다. 본 선정·협약으로 <strong>정부지원금·계약대가가 재단에 유입되지는 않습니다.</strong> 다만 비대가성 협력에도 재단이 부담하는 내부 인력·운영 비용은 존재할 수 있으며, 이는 아래 Figure 7.1의 &ldquo;0원&rdquo;에 포함되지 않습니다. 본 선정·협약은 MOC 시장 가치에 대한 직접적 인과를 시사하지 않습니다.</p><p class="lang-en"><strong>Selection and execution of the agreement did not change the non-compensatory, non-equity terms stated in the 4/21 disclosure.</strong> No government grant or matching funds are transferred to the Foundation, and its role remains limited to joint R&amp;D and standardization cooperation exactly as disclosed on 4/21. <strong>No government funding or contractual consideration flows to the Foundation as a result of this selection or agreement.</strong> Even in a non-compensatory arrangement, however, the Foundation may bear internal personnel and operating costs, and those are not included in the "KRW 0" shown in Figure 7.1 below. This selection and agreement imply no direct causal link to the market value of MOC.</p>
+<p class="lang-ko"><strong>보도된 &ldquo;2년간 750억원&rdquo;은 선정 26개 과제 전체에 대한 정부 지원 총액이며, 재단의 수령액이 아닙니다.</strong> 공개된 배분은 Agile 트랙 16개 과제 600억원 · <strong>Build-up 트랙 10개 과제 150억원</strong>이고, 재단 참여 과제는 후자에 속합니다. 과제별 배분액은 공표되지 않았으며, 어느 경우에도 <strong>재단으로 이전되는 금액은 없습니다(0원)</strong> — 과제 예산은 컨소시엄 주관·참여기관에 정부 R&amp;D 회계 절차에 따라 집행됩니다. <span class="vb v1">V1</span></p><p class="lang-en"><strong>The reported "KRW 75.0bn over two years" is the total government support for all 26 selected projects, not an amount received by the Foundation.</strong> The published allocation is KRW 60.0bn across 16 Agile-track projects and <strong>KRW 15.0bn across 10 Build-up-track projects</strong>, and the Foundation's project sits in the latter. Per-project allocations have not been published, and in no case is <strong>any amount transferred to the Foundation (KRW 0)</strong> — project budgets are disbursed to the consortium's lead and participating institutions under government R&amp;D accounting procedures. <span class="vb v1">V1</span></p>
+<p class="lang-ko"><strong>후속 공시는 분기 내에 발행되지 않았고, 분기 종료 후인 2026-08-04에 발행되었습니다.</strong> 4/21 공시는 제6항 5)에서 &ldquo;구체적 진행 사항은 공식 채널로 별도 안내된다&rdquo;고 밝혔고, 같은 항 3)에서 그 공시가 신청(제안) 단계에 한정되며 정부의 과제 선정·집행에 관한 사항이 아님을 명시했습니다. 선정과 협약 체결은 그 &ldquo;구체적 진행 사항&rdquo;에 해당하는 별도 안내 대상이었으나, 6/25 발표와 7/10 협약 체결 이후에도 재단은 분기 내에 해당 공시를 발행하지 않았습니다. 4/21 공시는 발행 기한을 정하고 있지 않으므로 <strong>공시 방침 위반은 아니나</strong>, 본 리포트가 2분기 자체 목표로 제시한 항목이므로 §1.2 항목 4의 <strong>미달 판정은 그대로 유지됩니다.</strong> 공표·협약·발행의 시점은 공시 본문 §5에 기재되어 있으며, 예고된 공시 항목의 이행 관리 절차는 §13.1의 <strong>상시 운영 규범</strong>으로 발효합니다(분기 목표가 아니므로 판정 대상은 아니며, 위반 사례가 발생하면 해당 분기 리포트에 기재합니다). <strong>본 리포트는 이 사실에 대한 공시를 대체하지 않으며, 정식 공시는 공시 저장소에 별도 발행되었습니다</strong> — 문서번호 MOSS-DISC-2026-0804 · 원문: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up.pdf" target="_blank" rel="noopener">공시 PDF (KO)</a> · <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up_en.pdf" target="_blank" rel="noopener">EN</a> <span class="vb v1">V1</span></p><p class="lang-en"><strong>The follow-up disclosure was not published within the quarter; it was published on 2026-08-04, after quarter-end.</strong> In §6-5 the 4/21 disclosure stated that "specific progress will be announced separately via official channels", and in §6-3 of the same section it stated that the disclosure was limited to the application (proposal) stage and did not concern the government's selection or execution of the project. The selection and the execution of the agreement were exactly such "specific progress" and thus called for a separate announcement, yet the Foundation published no such disclosure within the quarter even after the 6/25 announcement and the 7/10 agreement. Because the 4/21 disclosure set no publication deadline, this is <strong>not a breach of that commitment</strong>; but it was an item this report set as a Q2 target of its own, so the <strong>missed assessment in §1.2 item 4 stands.</strong> The dates of the announcement, the agreement and publication are recorded in §5 of the disclosure itself, and the procedure for tracking promised disclosure items is in force as a <strong>standing operating rule</strong> in §13.1 (not a quarterly target and so not assessed; any breach is recorded in that quarter's report). <strong>This report does not substitute for disclosure of these facts; the formal disclosure was published separately in the disclosure repository</strong> — document number MOSS-DISC-2026-0804 · originals: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up.pdf" target="_blank" rel="noopener">Disclosure PDF (KO)</a> · <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up_en.pdf" target="_blank" rel="noopener">EN</a> <span class="vb v1">V1</span></p>
+
+<figure class="viz" aria-label="AX Sprint funding attribution">
+  <div class="vizscroll"><svg viewBox="0 0 900 168" role="img" aria-label="AX Sprint funding attribution">
+<rect x="40" y="34" width="240" height="92" fill="#fff" stroke="#cecac1" stroke-width="1.4"/>
+<text x="160" y="54" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068">국토교통부 소관 공모 전체</text>
+<text x="160" y="87" text-anchor="middle" font-family="Georgia,serif" font-size="26" font-weight="bold" fill="#111418">750억원</text>
+<text x="160" y="110" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9" fill="#5b6068">26개 과제 · 2년 정부 지원 총액</text>
+<rect x="330" y="34" width="240" height="92" fill="#fff" stroke="#cecac1" stroke-width="1.4"/>
+<text x="450" y="54" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068">재단 컨소시엄이 속한 트랙</text>
+<text x="450" y="87" text-anchor="middle" font-family="Georgia,serif" font-size="26" font-weight="bold" fill="#111418">150억원</text>
+<text x="450" y="110" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9" fill="#5b6068">Build-up 트랙 10개 과제 · 2026~2027</text>
+<rect x="620" y="34" width="240" height="92" fill="#e5efec" stroke="#15665c" stroke-width="1.4"/>
+<text x="740" y="54" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068">모스랜드 재단 이전액</text>
+<text x="740" y="87" text-anchor="middle" font-family="Georgia,serif" font-size="26" font-weight="bold" fill="#0d4a43">0원</text>
+<text x="740" y="110" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="9" fill="#5b6068">비대가성 · 비출자 — 자금 이전 없음</text>
+<text x="287" y="88" text-anchor="middle" font-family="Georgia,serif" font-size="26" fill="#cecac1">›</text>
+<text x="287" y="26" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="8.5" fill="#5b6068">트랙 부분집합</text>
+<text x="577" y="88" text-anchor="middle" font-family="Georgia,serif" font-size="26" fill="#cecac1">›</text>
+<text x="577" y="26" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="8.5" fill="#5b6068">재단 이전 없음</text>
+<text x="40" y="150" font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#5b6068">과제 예산은 컨소시엄 주관·참여기관에 정부 R&amp;D 회계 절차로 집행되며, 과제별 배분액은 공표되지 않았습니다. Agile 트랙 16개 과제 600억원 + Build-up 트랙 10개 과제 150억원 = 750억원.</text>
+</svg></div>
+  <figcaption>Figure 7.1 · <span class="lang-ko">AX Sprint 지원 규모의 <strong>귀속 관계</strong>. 보도된 750억원은 선정 26개 과제 전체에 대한 2년간 정부 지원 총액이며, 재단으로 이전되는 금액은 없습니다. <strong>세 값은 금액이 단계적으로 줄어드는 과정이 아니라 서로 다른 범위의 값입니다</strong> — 첫 화살표는 트랙 부분집합(750억원 중 Build-up 트랙 몫), 둘째 화살표는 계약 형태(비대가성·비출자로 재단 이전 없음)를 뜻합니다. 동일 내용이 2026-08-04 공시(MOSS-DISC-2026-0804) §3에 기재되어 있습니다.</span><span class="lang-en"><strong>Attribution</strong> of the AX Sprint funding. The reported KRW 75.0bn is the total two-year government support for all 26 selected projects, and no amount is transferred to the Foundation. <strong>The three values are not a stepwise reduction of one amount but figures of different scope</strong> — the first arrow denotes a track subset (the Build-up track's share of the KRW 75.0bn), and the second denotes the form of the arrangement (non-compensatory and non-equity, so nothing is transferred to the Foundation). The same content appears in §3 of the 2026-08-04 disclosure (MOSS-DISC-2026-0804).</span></figcaption>
+</figure>
+
+<h4><span class="lang-ko">컨소시엄 기술축 연계 워크스트림 — 디지털 트윈 트랙 (1,086 commits)</span><span class="lang-en">Workstream aligned with the consortium's technical track — the digital twin track (1,086 commits)</span></h4>
+<p class="lang-ko">2분기 추적 GitHub 활동의 55.8%가 이 워크스트림에서 기록되었습니다. 본 절은 위 공시 요지와 동일한 익명화 수위를 적용하며, 컨소시엄 주관기관·제품의 명칭, 기능 사양, 파일럿 현장의 식별 정보를 공시 PDF에 기재된 수준을 넘어 기술하지 않습니다. 해당 워크스트림에서 관찰된 작업은 다음 범위에서만 기술합니다(수행·비용·귀속은 §6.3).</p><p class="lang-en">55.8% of tracked GitHub activity in Q2 was recorded in this workstream. This section applies the same level of anonymisation as the disclosure summary above, and does not describe the names of the consortium lead or its products, functional specifications, or identifying details of the pilot sites beyond what the disclosure PDF states. The work observed in this workstream is described only within the following scope (performance, cost and attribution are covered in §6.3).</p>
+<ul>
+  <li><span class="lang-ko"><strong>변환·렌더링 계층</strong> — 건물 모델을 웹 브라우저에서 구동하기 위한 변환 파이프라인과 런타임 렌더러. 대용량 모델의 로딩·렌더 효율, 대규모 씬의 프레임 안정성, 모델·온톨로지 관리 도구.</span><span class="lang-en"><strong>Conversion and rendering layer</strong> — the conversion pipeline and runtime renderer for running building models in a web browser: load and render efficiency for large models, frame stability in large scenes, and model/ontology management tooling.</span></li>
+  <li><span class="lang-ko"><strong>운영 계층</strong> — 실제 건물의 운영 신호를 트윈에 연결하는 작업. 영상 탐지 스트림, IoT 디바이스 매핑, 재실(occupancy) 신호, 층별 모니터링 화면.</span><span class="lang-en"><strong>Operations layer</strong> — connecting a real building's operational signals to the twin: video detection streams, IoT device mapping, occupancy signals, and floor-by-floor monitoring screens.</span></li>
+  <li><span class="lang-ko"><strong>계층 간 연동</strong> — 분기 중 두 계층이 연결되어 하나의 트랙으로 진행되었습니다. 이 연동이 "현실 신호가 루프에 들어온다"는 분기 서사의 기술적 실체입니다.</span><span class="lang-en"><strong>Integration between the layers</strong> — during the quarter the two layers were connected and proceeded as a single track. That integration is the technical substance behind the quarter's narrative that "real-world signals enter the loop".</span></li>
+</ul>
+<p class="small lang-ko">본 트랙의 커밋은 <strong>재단 GitHub 조직에서 발생한 개발 활동</strong>을 기준으로 집계한 것이며, 컨소시엄 협약에 따른 성과물·지식재산의 귀속과는 별개의 지표입니다. 커밋 수는 개발 활동량의 지표일 뿐 자산 보유나 매출을 의미하지 않습니다(§10 · §A.2). <span class="vb v3">V3</span></p><p class="small lang-en">Commits on this track are counted on the basis of <strong>development activity occurring in the Foundation's GitHub organisations</strong>, and are a separate indicator from where the output and intellectual property vest under the consortium agreement. A commit count is an indicator of development activity only; it does not signify assets held or revenue (§10 · §A.2). <span class="vb v3">V3</span></p>
+
+<h3 id="s7.2">7.2 <span class="lang-ko">Passport — 보유가 검증 가능한 참여가 되는 곳</span><span class="lang-en">Passport</span></h3>
+<p class="lang-ko"><a href="https://passport.moss.land" target="_blank" rel="noopener">passport.moss.land</a> <span class="lock">🔒</span> <span class="lang-ko">비공개 저장소</span><span class="lang-en">private repository</span> <span class="vb v2">V2</span></p><p class="lang-en"><a href="https://passport.moss.land" target="_blank" rel="noopener">passport.moss.land</a> <span class="lock">🔒</span> private repository <span class="vb v2">V2</span></p>
+<p class="lang-ko">MOC 보유자가 지갑 서명으로 해당 주소에 대한 통제권과 보유 상태를 증명하고 참여 기록을 한곳에서 확인하는 서비스입니다. 6/9 개발 착수 → <strong>6/10 첫 배포</strong> → 6/30 오픈베타 공개까지 3주간 v1.0 → v1.6으로 반복 배포되었습니다. 전 과정이 트랜잭션이 아닌 <strong>서명 기반(가스비 0)</strong>이며, 개인키·시드 구문을 요구하지 않습니다.</p><p class="lang-en">A service where MOC holders prove, by wallet signature, their control of an address and its holding status, and can see their participation record in one place. From development start on 6/9 → <strong>first deployment 6/10</strong> → open beta on 6/30, it shipped iteratively from v1.0 to v1.6 over three weeks. The whole flow is <strong>signature-based rather than transactional (zero gas)</strong> and never asks for a private key or seed phrase.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">기능 축</span><span class="lang-en">Capability</span></th><th><span class="lang-ko">내용</span><span class="lang-en">Detail</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">인증 · 위임</span><span class="lang-en">Authentication · delegation</span></td><td><span class="lang-ko">지갑 서명 인증(SIWE) · 거버넌스 투표권 위임 (Governance Ready)</span><span class="lang-en">Wallet signature authentication (SIWE) · delegation of governance voting power (Governance Ready)</span></td></tr>
+    <tr><td><span class="lang-ko">전환 지원</span><span class="lang-en">Transition support</span></td><td><span class="lang-ko">거래소 → 자가지갑 출금 수수료 보전 신청·처리 (Activation Support, 지갑당 월 1회) · 거래소별 보전 기준 공시</span><span class="lang-en">Applications for, and processing of, reimbursement of withdrawal fees from exchanges to self-custody (Activation Support, once per wallet per month) · reimbursement criteria published per exchange</span></td></tr>
+    <tr><td><span class="lang-ko">복귀 경로</span><span class="lang-en">Exit path</span></td><td><span class="lang-ko">가스비 없이 서명만으로 자가지갑에서 되돌아가는 Exit Pass</span><span class="lang-en">Exit Pass, which returns from self-custody by signature alone, with no gas fee</span></td></tr>
+    <tr><td><span class="lang-ko">투명성</span><span class="lang-en">Transparency</span></td><td><span class="lang-ko">참여 기록 공개(서명의 벽 — 공개 게시에 동의한 서명만 게시하며, 게시된 항목은 브라우저에서 독립 검증 가능. 비공개 선택 서명은 게시하지 않음) · 운영 지표 투명성 페이지 · 개인정보 동의·철회 체계</span><span class="lang-en">Public participation record (the Wall of Signatures — only signatures whose owners consented to public posting are shown, and posted entries can be independently verified in the browser; signatures marked private are not posted) · an operational-metrics transparency page · a consent and withdrawal framework for personal data</span></td></tr>
+    <tr><td><span class="lang-ko">운영</span><span class="lang-en">Operations</span></td><td><span class="lang-ko">자동 배포 파이프라인 · 야간 백업과 복원 검증 · 이상 상황 알림</span><span class="lang-en">Automated deployment pipeline · nightly backups with restore verification · anomaly alerting</span></td></tr>
+  </tbody>
+</table>
+<p class="lang-ko">설계 의도는 보상 프로그램이 아니라 <strong>참여 자격 인프라</strong>입니다. Passport가 확인하는 것은 <strong>해당 주소의 통제권과 체크인 시점의 MOC 보유 상태</strong>이며(서명은 법적 소유가 아니라 통제권을 증명합니다), 실명확인(KYC)이나 개인 신원 확인은 수행하지 않습니다 — 확인 단위는 사람이 아니라 주소입니다. 거래소 보관 물량에는 투표권이 없으므로, 인증·위임을 마친 자가지갑만 시그널 투표에 참여합니다. 이는 §9.3의 거버넌스 재정비 서사와 직결되며, 오픈베타가 분기 마지막 날 시작되었으므로 채택 지표(인증 지갑 수 등)는 3분기부터 공식 집계합니다(발행일 시점 초기 관측치는 §12).</p><p class="lang-en">The design intent is not a rewards programme but <strong>eligibility infrastructure</strong>. What Passport confirms is <strong>control of the address and its MOC holding status at the moment of check-in</strong> (a signature proves control, not legal ownership); it performs no real-name (KYC) or personal identity verification — the unit of verification is an address, not a person. Balances held on exchanges carry no voting power, so only self-custody wallets that have completed authentication and delegation take part in signal votes. This connects directly to the governance rebuild described in §9.3, and because the open beta began on the last day of the quarter, adoption metrics (verified wallet count and so on) will be counted officially from Q3 (initial observations as of the publication date are in §12).</p>
+
+<h3 id="s7.3">7.3 <span class="lang-ko">Agora 재정비 · MAIT 통합 결정</span><span class="lang-en">Agora Overhaul &amp; MAIT Consolidation</span></h3>
+<p class="lang-ko"><a href="https://agora.moss.land" target="_blank" rel="noopener">agora.moss.land</a> <span class="lock">🔒</span> <span class="lang-ko">비공개 저장소</span><span class="lang-en">private repository</span> <span class="vb v2">V2</span> · <span class="lang-ko">공개 문서 저장소</span><span class="lang-en">public documentation repository</span> <a href="https://github.com/MosslandOpenDevs/Agora" target="_blank" rel="noopener">MosslandOpenDevs/Agora</a></p><p class="lang-en"><a href="https://agora.moss.land" target="_blank" rel="noopener">agora.moss.land</a> <span class="lock">🔒</span> private repository <span class="vb v2">V2</span> · public documentation repository <a href="https://github.com/MosslandOpenDevs/Agora" target="_blank" rel="noopener">MosslandOpenDevs/Agora</a></p>
+<p class="lang-ko">2분기의 Agora는 기능 추가가 아니라 <strong>인증·보안 기반을 다시 세우는 구간</strong>이었습니다. 6/25 재정비 착수 후 분기 내 완료된 작업은 다음과 같습니다.</p><p class="lang-en">Agora in Q2 was <strong>a stretch of rebuilding the authentication and security foundations</strong> rather than adding features. Work completed within the quarter after the rebuild began on 6/25:</p>
+<ul>
+  <li><span class="lang-ko">지갑 로그인 방식을 서버 발급 nonce + 보안 쿠키 체계로 교체 — Passport와 동일한 인증 규범으로 정렬</span><span class="lang-en">Replaced wallet login with a server-issued nonce plus secure cookie scheme — aligned to the same authentication norms as Passport</span></li>
+  <li><span class="lang-ko">구형 web3 라이브러리를 ethers v6로 통합, 실행 환경 최신화</span><span class="lang-en">Consolidated legacy web3 libraries onto ethers v6 and modernised the runtime environment</span></li>
+  <li><span class="lang-ko">문서에 남아 있던 사실과 다른 설명 13건 정정</span><span class="lang-en">Corrected 13 statements in the documentation that did not match the facts</span></li>
+</ul>
+<p class="lang-ko">제안 자격 기준·검색 요약·위임 투표권 반영 등 기능 본편은 7월에 진행되었습니다(§12).</p><p class="lang-en">The main feature work — proposal eligibility criteria, search summaries and delegated voting power — was carried out in July (§12).</p>
+
+<h4><span class="lang-ko">MAIT — 현대화 착수 후 통합으로 방향 전환</span><span class="lang-en">MAIT — modernisation started, then redirected to consolidation</span></h4>
+<p class="lang-ko"><span class="lang-ko">MAIT</span><span class="lang-en">MAIT</span> <span class="lock">🔒</span> <span class="lang-ko">비공개 저장소</span><span class="lang-en">private repository</span></p><p class="lang-en">MAIT <span class="lock">🔒</span> private repository</p>
+<p class="lang-ko">2025년 출시된 DAO AI 툴킷 MAIT는 6/27부터 최신 스택으로 현대화되었습니다 — Spring Boot 4.1 + JDK 25 전환, 프론트엔드 최신화, 지갑 서명 로그인 도입, 세션·인증 보안 보강, 레거시 코드 제거. 이 작업은 <strong>서비스 존속을 전제로 착수</strong>했으나, 정비를 마친 코드베이스를 놓고 재평가한 결과 MAIT의 핵심 가치(AI 요약·이해 지원, 거버넌스 연동)는 독립 서비스보다 Passport·Agora에 통합하는 편이 낫다는 판단에 도달했습니다. 통합 실행과 서비스 종료는 7월 초에 진행되었습니다(§12). 현대화 작업의 일부는 Passport·Agora로 이관되어 재사용되었으나, 독립 서비스 유지를 전제로 투입된 부분은 통합 결정과 함께 소멸했습니다. 본 리포트는 이를 <strong>계획된 사전 검증이 아니라, 판단이 정비 이후에 내려진 사례</strong>로 기록합니다. 분기말 시점 기준으로 MAIT는 운영 중이었음을 명확히 합니다.</p><p class="lang-en">MAIT, the DAO AI toolkit released in 2025, was modernised onto a current stack from 6/27 — migration to Spring Boot 4.1 + JDK 25, front-end modernisation, wallet-signature login, hardened session and authentication security, and removal of legacy code. This work <strong>began on the assumption that the service would continue</strong>, but on reassessing the tidied codebase the conclusion was that MAIT's core value (AI summarisation and comprehension support, governance integration) was better folded into Passport and Agora than kept as a standalone service. The consolidation and the service's retirement took place in early July (§12). Part of the modernisation work was carried over into Passport and Agora and reused, while the part invested on the assumption of a standalone service was written off along with the consolidation decision. This report records it as <strong>a case where the judgement was made after the tidy-up rather than as planned prior validation</strong>. To be clear, MAIT was still operating as at quarter-end.</p>
+
+<h3 id="s7.4">7.4 <span class="lang-ko">에이전트 시스템 — Algora · AO · BRIDGE</span><span class="lang-en">Agent Systems</span></h3>
+
+<h4>Algora · <a href="https://github.com/MosslandOpenDevs/Algora" target="_blank" rel="noopener">GitHub</a> · 34 commits · <a href="https://algora.moss.land" target="_blank" rel="noopener">algora.moss.land</a> <span class="vb v1">V1</span></h4>
+<p class="lang-ko">24/7 에이전트 거버넌스 실험. 2분기 커밋은 6월 하순 <strong>공개 서비스 수준 정비</strong>에 집중되었습니다 — 지갑 서명 기반 위임, 공개 쓰기 엔드포인트 접근 통제, <strong>시뮬레이션 데이터의 명시적 라벨링</strong>(실데이터로 오인 방지), 접근성(WCAG 대비·키보드·모션), 다크모드·SEO·PWA 정비, 그리고 6/30 Passport의 무청구(claim-less) 등록 규범과 공개 문구 정렬. 공개 대시보드 기준 완결 세션 10건이 집계되어 있습니다. 6/17 소개 포스트로 대외 공개되었습니다.</p><p class="lang-en">The 24/7 agent governance experiment. Q2 commits were concentrated in late June on <strong>bringing it to public-service quality</strong> — wallet-signature-based delegation, access control on public write endpoints, <strong>explicit labelling of simulation data</strong> (to prevent it being mistaken for real data), accessibility (WCAG contrast, keyboard, motion), dark mode, SEO and PWA work, and on 6/30 alignment with Passport's claim-less registration norms and public wording. Ten completed sessions are counted on the public dashboard. It was published externally with an introductory post on 6/17.</p>
+
+<h4>Agentic Orchestrator (AO) · <a href="https://github.com/MosslandOpenDevs/agentic-orchestrator" target="_blank" rel="noopener">GitHub</a> · 113 commits · <a href="https://ao.moss.land" target="_blank" rel="noopener">ao.moss.land</a> <span class="vb v1">V1</span></h4>
+<p class="lang-ko">신호 수집 → 34 페르소나 토론 → 서비스 기획안 자동 생성 파이프라인. 누적 집계(2026-08-03 관측)는 시그널 33,307 → 아이디어 1,230 → 플랜 172 → <strong>프로젝트 66건</strong>이며, 6월 초에는 실제 운영 이슈(토큰 출금 병목 등)를 입력으로 한 기획안의 코드 생성까지 도달했습니다. 6월 하순 저장소에는 <strong>DB 유실 대비 복원력 강화(v0.6.10)</strong> — 스키마 자가 복구·롤링 백업·백업 무결성·상태 열화 표시 — 와 코드 생성 검증 게이트(v0.6.9), CI 정상화, 접근성·보안 일괄 정비가 집중되었습니다.</p><p class="lang-en">A pipeline running signal collection → debate among 34 personas → automatic generation of service plans. Cumulative figures (observed 2026-08-03) are 33,307 signals → 1,230 ideas → 172 plans → <strong>66 projects</strong>, and by early June it reached code generation from a plan whose input was a real operational issue (a token withdrawal bottleneck, among others). Late June work in the repository concentrated on <strong>resilience against database loss (v0.6.10)</strong> — schema self-healing, rolling backups, backup integrity checks and degraded-state reporting — together with a code-generation verification gate (v0.6.9), restoring CI, and a sweep of accessibility and security work.</p>
+
+<h4>BRIDGE · <a href="https://github.com/MosslandOpenDevs/bridge-2026" target="_blank" rel="noopener">GitHub</a> · 8 commits · <a href="https://bridge.moss.land" target="_blank" rel="noopener">bridge.moss.land</a> <span class="vb v1">V1</span></h4>
+<p class="lang-ko">Reality Oracle → Inference Mining → Agentic Consensus 루프의 Physical AI Governance OS 연구 프리뷰. 2분기는 대규모 개발 없이 연구 단계를 유지했으며, 6/30 소개 포스트로 개념을 대외 공개했습니다. 디지털 트윈 트랙(§7.1)이 만들어내는 현실 신호가 장기적으로 BRIDGE의 입력이 되는 구도입니다.</p><p class="lang-en">A research preview of a Physical AI Governance OS implementing the Reality Oracle → Inference Mining → Agentic Consensus loop. Q2 kept it at the research stage without major development, and the concept was published externally in the 6/30 introductory post. The structure is that real-world signals produced by the digital twin track (§7.1) become BRIDGE's input over the longer term.</p>
+
+<h3 id="s7.5">7.5 <span class="lang-ko">AI 미디어 · 시티 클러스터 — 5월의 집중 실험</span><span class="lang-en">AI Media &amp; City Cluster</span></h3>
+<p class="lang-ko">4/30~5/12 사이 저장소가 개설되고 5월 중 순차 공개된 6개 서비스의 묶음입니다. 클러스터 합계는 259커밋(공개 41 · 비공개 218)이며, 비공개 저장소는 §6.3 표기 원칙에 따라 개별 커밋 수를 표기하지 않습니다. 공통 구조는 <strong>Signal Map이 수집·정규화한 신호를 상류로 삼아</strong> 각 서비스가 다른 형태(미디어·커뮤니티·시뮬레이션·캐릭터)로 소비하는 파이프라인이며, 5월 집중 구축 후 6월부터는 자동 파이프라인 운영 체제로 전환되었습니다. 채택·트래픽 지표는 아직 공식 집계 전입니다.</p><p class="lang-en">A bundle of six services whose repositories were created between 4/30 and 5/12 and which were published in sequence during May. The cluster totals 259 commits (public 41 · private 218); individual commit counts for private repositories are not shown, per the convention in §6.3. The shared structure is a pipeline in which <strong>Signal Map's collected and normalised signals act as the upstream</strong> and each service consumes them in a different form (media, community, simulation, characters). After the concentrated build in May, operation moved to an automated pipeline from June. Adoption and traffic metrics are not yet officially counted.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">서비스</span><span class="lang-en">Service</span></th><th>Commits</th><th><span class="lang-ko">역할</span><span class="lang-en">Role</span></th></tr></thead>
+  <tbody>
+    <tr><td><a href="https://signalmap.moss.land" target="_blank" rel="noopener">Signal Map</a> · <span class="lock">🔒</span></td><td>—</td><td><span class="lang-ko">YouTube·뉴스·매크로 피드를 엔티티·토픽·이벤트의 정규 저장소로 통합하는 상류 파이프라인. 일간(무료)·주간(LLM) 크론 분리 운영.</span><span class="lang-en">The upstream pipeline consolidating YouTube, news and macro feeds into a normalised store of entities, topics and events. Daily (free) and weekly (LLM) cron runs are operated separately.</span></td></tr>
+    <tr><td><a href="https://alpha.moss.land" target="_blank" rel="noopener">Alpha</a> · <a href="https://github.com/MosslandOpenDevs/alpha" target="_blank" rel="noopener"><span class="lang-ko">GitHub 공개</span><span class="lang-en">public on GitHub</span></a></td><td>41</td><td><span class="lang-ko">크립토 버티컬 미디어 — 채널별 스탠스 분포, AI 데일리 브리프, RAG Q&amp;A, 공개 AI 페르소나 8종, LLM 에이전트용 MCP 12툴. 사람과 LLM 모두가 인용 가능한 매체 지향. 운영 중 LLM 비용 상한·레이트리밋 도입.</span><span class="lang-en">Crypto vertical media — stance distribution by channel, an AI daily brief, RAG Q&amp;A, 8 public AI personas and 12 MCP tools for LLM agents. Aimed at being media that both people and LLMs can cite. An LLM cost ceiling and rate limiting were introduced during operation.</span></td></tr>
+    <tr><td><a href="https://npc.moss.land" target="_blank" rel="noopener">NPC</a> · <span class="lock">🔒</span></td><td>—</td><td><span class="lang-ko">페르소나·장기 기억을 가진 디지털 주민. 야간 파이프라인이 시장·뉴스·커뮤니티 흐름을 캐릭터 목소리의 헤드라인으로 발행. 5월 중 주민 15종 추가·주간 칼럼 체계 도입.</span><span class="lang-en">Digital residents with persona and long-term memory. A nightly pipeline publishes market, news and community flows as headlines in each character's voice. 15 residents were added during May and a weekly column format was introduced.</span></td></tr>
+    <tr><td><a href="https://city.moss.land" target="_blank" rel="noopener">City</a> · <span class="lock">🔒</span></td><td>—</td><td><span class="lang-ko">NPC·Alpha·Algora·AO·BRIDGE의 실시간 신호를 하나의 가상 도시 일상으로 집약하는 AI 사회 시뮬레이션. 일별 아카이브·연구용 데이터셋 엔드포인트 공개.</span><span class="lang-en">An AI social simulation gathering real-time signals from NPC, Alpha, Algora, AO and BRIDGE into the daily life of a single virtual city. Daily archives and a research dataset endpoint are published.</span></td></tr>
+    <tr><td><a href="https://media.moss.land" target="_blank" rel="noopener">Media</a> · <span class="lock">🔒</span></td><td>—</td><td><span class="lang-ko">Signal Map 위의 국내 AI·크립토 미디어 + 커뮤니티 (엔티티 보드·게시글·투표, 5개 인증 제공자).</span><span class="lang-en">Domestic AI and crypto media plus community on top of Signal Map (entity boards, posts, voting, 5 authentication providers).</span></td></tr>
+    <tr><td><a href="https://recipe.moss.land" target="_blank" rel="noopener">Recipe</a> · <span class="lock">🔒</span></td><td>—</td><td><span class="lang-ko">화제의 AI 결과물을 보고 따라 만드는 트렌드 레시피 갤러리.</span><span class="lang-en">A trend recipe gallery for following along and reproducing notable AI outputs.</span></td></tr>
+  </tbody>
+</table>
+
+<h3 id="s7.6">7.6 <span class="lang-ko">Mossverse · links</span><span class="lang-en">Mossverse &amp; links</span></h3>
+<h4>Mossverse (wa.moss.land) — <span class="lang-ko">Passport 연동을 처음 적용한 서비스</span><span class="lang-en">The first service to adopt the Passport integration</span> <span class="vb v2">V2</span></h4>
+<p class="lang-ko"><a href="https://wa.moss.land" target="_blank" rel="noopener">wa.moss.land</a> · <span class="lang-ko">맵 저장소</span><span class="lang-en">map repository</span> <a href="https://github.com/MosslandOpenDevs/mossverse-wa-map" target="_blank" rel="noopener">공개</a>(14) · <span class="lang-ko">비공개 저장소</span><span class="lang-en">private repository</span> <span class="lock">🔒</span></p><p class="lang-en"><a href="https://wa.moss.land" target="_blank" rel="noopener">wa.moss.land</a> · map repository <a href="https://github.com/MosslandOpenDevs/mossverse-wa-map" target="_blank" rel="noopener">public</a> (14) · private repository <span class="lock">🔒</span></p>
+<ul>
+  <li><span class="lang-ko">4~5월 — 랜딩·로그인 화면 개편, 공유 미리보기·아이콘 정비</span><span class="lang-en">April–May — landing and login screens reworked, share previews and icons tidied</span></li>
+  <li><span class="lang-ko">6/23 — 배포 자동화 구축</span><span class="lang-en">6/23 — deployment automation built</span></li>
+  <li><span class="lang-ko">6/23~24 — <strong>Passport 연결 기능 도입</strong>: 전용 연결 페이지·동의 절차·동의 이력 기록, 연결 결과로 회원·MOC 보유자 구분을 서비스가 인식</span><span class="lang-en">6/23–24 — <strong>Passport connection introduced</strong>: a dedicated connection page, a consent flow and a consent history record, with the service recognising members versus MOC holders from the connection result</span></li>
+  <li><span class="lang-ko">6/30 — 보안 헤더 기준 정리, 운영 인계 문서 작성</span><span class="lang-en">6/30 — security header standards tidied, operational handover documentation written</span></li>
+</ul>
+<p class="lang-ko">Passport를 인증·자격 계층으로 쓰는 첫 번째 생태계 서비스로, "인증은 Passport에서 한 번, 각 서비스는 연결만"이라는 구조의 첫 사례입니다.</p><p class="lang-en">The first ecosystem service to use Passport as its authentication and eligibility layer, and the first case of the pattern "authenticate once in Passport; each service only connects".</p>
+
+<h4>links (links.moss.land) — <span class="lang-ko">공식 주소의 단일 기준점</span><span class="lang-en">A single reference point for official addresses</span> <span class="vb v1">V1</span></h4>
+<p class="lang-ko"><a href="https://links.moss.land" target="_blank" rel="noopener">links.moss.land</a> · <a href="https://github.com/MosslandOpenDevs/links" target="_blank" rel="noopener"><span class="lang-ko">GitHub 공개</span><span class="lang-en">public on GitHub</span></a> · 9 commits</p><p class="lang-en"><a href="https://links.moss.land" target="_blank" rel="noopener">links.moss.land</a> · <a href="https://github.com/MosslandOpenDevs/links" target="_blank" rel="noopener">public on GitHub</a> · 9 commits</p>
+<p class="lang-ko">6/29 시작. 공식 도메인·생태계 서비스·개발자 자료·거래소 정보를 한 페이지에 정리하고, <strong>"여기 없는 주소는 공식이 아니다"</strong>를 운영 기준으로 삼아 사칭·피싱 대응의 기준점 역할을 합니다. 한국어·영어 병기, 기계 판독용 <span class="mono">ecosystem-registry.json</span>·<span class="mono">llms.txt</span>를 함께 제공해 사람과 LLM 모두가 공식 주소를 확인할 수 있습니다.</p><p class="lang-en">Launched 6/29. It gathers official domains, ecosystem services, developer resources and exchange information onto a single page and, taking <strong>"an address not listed here is not official"</strong> as its operating rule, serves as the reference point for responding to impersonation and phishing. It is published in Korean and English and ships machine-readable <span class="mono">ecosystem-registry.json</span> and <span class="mono">llms.txt</span> so that both people and LLMs can confirm official addresses.</p>
+
+<h3 id="s7.7">7.7 <span class="lang-ko">프로젝트 상호 의존 지도</span><span class="lang-en">Project Interdependency Map</span></h3>
+<figure class="viz" aria-label="Project dependency map">
+  <div class="vizscroll"><svg viewBox="0 0 900 360" role="img">
+    <defs>
+      <marker id="arrQ2" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#6a7a8d"/>
+      </marker>
+      <marker id="arrMait" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+        <path d="M 0 0 L 10 5 L 0 10 z" fill="#8a6500"/>
+      </marker>
+    </defs>
+    <g font-family="Georgia,serif" font-size="13" fill="#111418">
+      <!-- auth & eligibility layer -->
+      <rect x="330" y="30" width="240" height="52" fill="#e5efec" stroke="#15665c"/>
+      <text x="450" y="52" text-anchor="middle" font-weight="bold">Passport</text>
+      <text x="450" y="70" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">wallet auth · eligibility · gas-0</text>
+      <!-- governance -->
+      <rect x="80" y="140" width="160" height="48" fill="#fff" stroke="#cecac1"/>
+      <text x="160" y="160" text-anchor="middle">Agora</text>
+      <text x="160" y="177" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">MIP voting</text>
+      <rect x="270" y="140" width="160" height="48" fill="#fff" stroke="#cecac1"/>
+      <text x="350" y="160" text-anchor="middle">Mossverse</text>
+      <text x="350" y="177" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">first connector</text>
+      <rect x="460" y="140" width="160" height="48" fill="#fff" stroke="#cecac1"/>
+      <text x="540" y="160" text-anchor="middle">Algora</text>
+      <text x="540" y="177" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">agent debate</text>
+      <rect x="650" y="140" width="170" height="48" fill="#f1efe9" stroke="#8a6500" stroke-dasharray="4 3"/>
+      <text x="735" y="160" text-anchor="middle" fill="#5b6068">MAIT</text>
+      <text x="735" y="177" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#8a6500">live at Q2-end · ended Jul</text>
+      <!-- media pipeline -->
+      <rect x="80" y="250" width="180" height="48" fill="#fbf2d9" stroke="#c68f2a"/>
+      <text x="170" y="270" text-anchor="middle">Signal Map</text>
+      <text x="170" y="287" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">upstream signals</text>
+      <rect x="310" y="250" width="300" height="48" fill="#fff" stroke="#cecac1"/>
+      <text x="460" y="270" text-anchor="middle">Alpha · Media · City · NPC · Recipe</text>
+      <text x="460" y="287" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">downstream surfaces</text>
+      <!-- DT track -->
+      <rect x="650" y="250" width="170" height="48" fill="#e5efec" stroke="#0d4a43"/>
+      <text x="735" y="270" text-anchor="middle" font-weight="bold">디지털 트윈 트랙</text>
+      <text x="735" y="287" text-anchor="middle" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">engine → live building</text>
+    </g>
+    <g stroke="#6a7a8d" stroke-width="1.2" fill="none" marker-end="url(#arrQ2)">
+      <line x1="410" y1="82" x2="180" y2="138"/>
+      <line x1="440" y1="82" x2="355" y2="138"/>
+      <line x1="470" y1="82" x2="530" y2="138"/>
+      <line x1="260" y1="274" x2="308" y2="274"/>
+    </g>
+    <g stroke="#8a6500" stroke-width="1.2" fill="none" stroke-dasharray="4 3" marker-end="url(#arrMait)">
+      <path d="M 690 140 L 566 86"/>
+      <path d="M 735 188 L 735 218 L 160 218 L 160 192"/>
+    </g>
+    <g font-family="ui-monospace,Menlo,monospace" font-size="9.5" fill="#8a6500">
+      <text x="700" y="112">거버넌스 연동 규격 → Passport</text>
+      <text x="440" y="213" text-anchor="middle">AI 요약 · 이해 지원 기능 → Agora</text>
+    </g>
+    <text x="20" y="330" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#5b6068">Passport = auth &amp; eligibility layer · Signal Map = signal layer · digital twin track = reality layer (future BRIDGE input)</text>
+    <text x="20" y="347" font-family="ui-monospace,Menlo,monospace" font-size="10" fill="#8a6500">실선 = 분기말(6/30) 기준 의존 · 점선 = 분기 이후(7월 초) MAIT 기능 이관 — 분기말 시점 MAIT는 운영 중 (§7.3 · §12)</text>
+  </svg></div>
+  <figcaption>Figure 7.7 · <span class="lang-ko">2분기말(6/30) 기준 서비스 의존 구조. Passport가 인증·자격 계층, Signal Map이 신호 계층, 디지털 트윈이 현실 계층을 맡습니다. MAIT는 <strong>분기말 시점 운영 중</strong>이었으며(§7.3), 점선은 분기 이후 7월 초에 실행된 기능 이관입니다 — 거버넌스 연동 규격은 Passport(7/2), AI 요약·이해 지원은 Agora(7/3)로 이관되고 MAIT는 운영 종료되었습니다(§12).</span><span class="lang-en">Service dependency structure as at quarter-end (6/30). Passport is the authentication and eligibility layer, Signal Map the signal layer, and the digital twin the reality layer. MAIT was <strong>still operating as at quarter-end</strong> (§7.3); the dashed lines are the capability transfers executed in early July, after the quarter — the governance integration specification moved to Passport (7/2) and AI summarisation/comprehension support to Agora (7/3), after which MAIT was retired (§12).</span></figcaption>
+</figure>
+
+<!-- ================= §8 ================= -->
+<h2 class="section" id="s8"><span class="num">§8</span><span class="lang-ko">커뮤니티 · 오픈소스 운영</span><span class="lang-en">Community &amp; Open-Source Operations</span></h2>
+
+<h3 id="s8.1">8.1 <span class="lang-ko">조직 현황 — 3개 GitHub 네임스페이스 구조 공시</span><span class="lang-en">Organization Structure</span></h3>
+<p class="lang-ko">1분기 리포트는 GitHub 조직을 2개로 기술했으나, 실제 개발은 3개 GitHub 네임스페이스에서 이루어집니다. 이번 분기부터 3개 GitHub 네임스페이스 구조를 공식 공시하며, 이는 §6의 집계 범위 확장과 짝을 이룹니다.</p><p class="lang-en">The Q1 report described two GitHub organisations, but development actually takes place across three GitHub namespaces. From this quarter the three-namespace structure is formally disclosed, paired with the widened counting scope in §6.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">조직</span><span class="lang-en">Namespace</span></th><th><span class="lang-ko">역할</span><span class="lang-en">Role</span></th><th><span class="lang-ko">Q2 커밋</span><span class="lang-en">Q2 commits</span></th></tr></thead>
+  <tbody>
+    <tr><td><a href="https://github.com/mossland" target="_blank" rel="noopener">github.com/mossland</a></td><td><span class="lang-ko">재단 공식 — 공시·프로젝트 포털·토큰 컨트랙트</span><span class="lang-en">Foundation official — disclosures, project portal, token contract</span></td><td>12</td></tr>
+    <tr><td><a href="https://github.com/MosslandOpenDevs" target="_blank" rel="noopener">github.com/MosslandOpenDevs</a></td><td><span class="lang-ko">오픈소스·연구·실험 — 공개 코드의 본거지</span><span class="lang-en">Open source, research and experiments — the home of public code</span></td><td>512</td></tr>
+    <tr><td><a href="https://github.com/MosslandCore" target="_blank" rel="noopener">github.com/MosslandCore</a></td><td><span class="lang-ko">운영 인프라 — 인가된 엔지니어 전용 (조직 설명에 "공개 코드는 MosslandOpenDevs에" 명시)</span><span class="lang-en">Operational infrastructure — authorised engineers only (the namespace description states that "public code lives in MosslandOpenDevs")</span></td><td>1,421</td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko">1분기 리포트가 &ldquo;2개 조직&rdquo;으로 기술하던 대상은 <strong>GitHub 네임스페이스 3개</strong>이며, 계정 유형은 <span class="mono">MosslandOpenDevs</span>·<span class="mono">MosslandCore</span>가 <strong>Organization</strong>, <span class="mono">mossland</span>가 <strong>User</strong> 계정입니다. GitHub API로 재현할 때 <span class="mono">mossland</span>는 <span class="mono">/users/</span> 엔드포인트를 사용해야 합니다(§A.3).</p><p class="small lang-en">What the Q1 report described as "two organisations" is in fact <strong>three GitHub namespaces</strong>, of which <span class="mono">MosslandOpenDevs</span> and <span class="mono">MosslandCore</span> are <strong>Organization</strong> accounts and <span class="mono">mossland</span> is a <strong>User</strong> account. When reproducing via the GitHub API, <span class="mono">mossland</span> must be queried through the <span class="mono">/users/</span> endpoint (§A.3).</p>
+<p class="small lang-ko">비공개 저장소의 존재와 총량을 공시하는 것은 "공개 저장소가 전부"라는 오해를 방지하기 위함입니다. 보안·운영상 코드를 공개할 수 없는 영역은 커밋 수(V3)와 결과 서비스(V2)로 활동을 공시합니다.</p><p class="small lang-en">Disclosing the existence and total volume of private repositories is intended to prevent the misconception that "the public repositories are all there is". For areas where code cannot be published for security or operational reasons, activity is disclosed through commit counts (V3) and the resulting services (V2).</p>
+
+<h3 id="s8.2">8.2 <span class="lang-ko">GitHub 공개 페이지 정비</span><span class="lang-en">Public Page Maintenance</span></h3>
+<ul>
+  <li><span class="lang-ko"><strong>6/9 — OpenDevs 조직 소개 페이지 재작성</strong> (<span class="mono">MosslandOpenDevs/.github</span> 커밋 3건 <span class="vb v1">V1</span>): 조직 설명문을 현재 활동에 맞게 갱신, 프로젝트별 상태 표기를 실제와 일치시키고(AI 미디어·MCP → 유지 중), 끊기거나 이전된 서비스 링크를 교체했습니다.</span><span class="lang-en"><strong>6/9 — the OpenDevs profile page was rewritten</strong> (<span class="mono">MosslandOpenDevs/.github</span>, 3 commits <span class="vb v1">V1</span>): the description was updated to match current activity, per-project status labels were brought into line with reality (AI media · MCP → maintained), and broken or relocated service links were replaced.</span></li>
+  <li><span class="lang-ko">프로젝트 포털(<a href="https://github.com/mossland/Projects" target="_blank" rel="noopener">mossland/Projects</a>) README 전면 갱신은 7/5에 진행되었습니다 (§12).</span><span class="lang-en">The full rewrite of the project portal README (<a href="https://github.com/mossland/Projects" target="_blank" rel="noopener">mossland/Projects</a>) took place on 7/5 (§12).</span></li>
+</ul>
+
+<h3 id="s8.3">8.3 <span class="lang-ko">기여 패턴 · 개발자 지원</span><span class="lang-en">Contribution &amp; Developer Support</span></h3>
+<p class="lang-ko">2분기 공개 저장소 기여는 조직 내부 기여자 계정의 직접 커밋이 중심이었습니다(고용 관계는 본 리포트가 확정하지 않습니다 — §6.3). 1분기 리포트가 약속한 외부 기여자·PR·이슈 해결 시간의 정량 집계는 이번 분기에도 도입되지 않았습니다(§1.2 항목 5). 다만 규모는 확인했습니다 — <strong>2분기 공개 저장소 PR은 19건(작성자 3명), 그중 조직 외부 기여자의 PR은 1건</strong>입니다. 이 규모에서는 별도 집계 파이프라인 구축의 실익이 없다고 판단해 <strong>자동 집계 파이프라인 구축은 보류</strong>합니다. 다만 <strong>공개 PR 총수 · 고유 작성자 수 · 조직 외부 기여자 PR 수는 분기 설명 지표로 수동 집계해 계속 공시</strong>합니다(§13.1). <span class="vb v1">V1</span> <a href="https://github.com/mossland/MosslandDeveloperSupportProgram" target="_blank" rel="noopener">MosslandDeveloperSupportProgram</a>(오픈소스 기여자 MOC 지급)은 제도로서 상시 유지되나, 2분기 중 신규 진행·지급 실적은 없었습니다(§2.6).</p><p class="lang-en">Q2 contributions to public repositories consisted mainly of direct commits from accounts belonging to members of the organisation (this report does not determine employment relationships — §6.3). The quantitative counting of external contributors, PRs and issue resolution time promised in the Q1 report was again not introduced this quarter (§1.2 item 5). The scale was, however, measured — <strong>Q2 saw 19 PRs in public repositories from 3 authors, of which 1 PR came from a contributor outside the organisation</strong>. At that scale, building a separate aggregation pipeline serves no practical purpose, so <strong>the automated pipeline is deferred</strong>. Total public PRs, distinct authors and PRs from contributors outside the organisation will nevertheless <strong>continue to be counted manually and disclosed as quarterly descriptive indicators</strong> (§13.1). <span class="vb v1">V1</span> <a href="https://github.com/mossland/MosslandDeveloperSupportProgram" target="_blank" rel="noopener">MosslandDeveloperSupportProgram</a> (MOC payouts to open-source contributors) is maintained as a standing programme, but there was no new activity and no payout during Q2 (§2.6).</p>
+
+<!-- ================= §9 ================= -->
+<h2 class="section" id="s9"><span class="num">§9</span><span class="lang-ko">거버넌스 · 법적 사항</span><span class="lang-en">Governance &amp; Legal</span></h2>
+
+<h3 id="s9.1">9.1 <span class="lang-ko">소송 — 대법원 최종 확정으로 절차 종결</span><span class="lang-en">Litigation — Final Judgment</span></h3>
+<p class="lang-ko">2024-01-29 「소송 등의 제기」 공시 건에 대한 최종 후속 공시가 6/11 발행되었습니다. 요지는 다음과 같습니다. <span class="vb v1">V1</span></p><p class="lang-en">The final follow-up disclosure on the 2024-01-29 "Notice of Litigation Commencement" was published on 6/11. Its substance is as follows. <span class="vb v1">V1</span></p>
+<table>
+  <thead><tr><th><span class="lang-ko">구분</span><span class="lang-en">Type</span></th><th><span class="lang-ko">내용</span><span class="lang-en">Detail</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">당사자</span><span class="lang-en">Parties</span></td><td><span class="lang-ko">원고 리얼리티리플렉션 주식회사 vs 피고 손OO(개인). <strong>모스랜드 재단은 본 소송의 당사자가 아닙니다.</strong></span><span class="lang-en">Plaintiff Reality Reflection Inc. v. defendant Mr./Ms. Son (an individual). <strong>The Mossland Foundation is not a party to this litigation.</strong></span></td></tr>
+    <tr><td><span class="lang-ko">1심 (서울동부지법)</span><span class="lang-en">First instance (Seoul Eastern District Court)</span></td><td><span class="lang-ko">2025-04-10 — 원고 청구 전부 기각</span><span class="lang-en">2025-04-10 — the plaintiff's claims were dismissed in full</span></td></tr>
+    <tr><td><span class="lang-ko">2심 (서울고법)</span><span class="lang-en">Second instance (Seoul High Court)</span></td><td><span class="lang-ko">2026-02-05 — 원고 항소 전부 기각</span><span class="lang-en">2026-02-05 — the plaintiff's appeal was dismissed in full</span></td></tr>
+    <tr><td><span class="lang-ko">3심 (대법원)</span><span class="lang-en">Third instance (Supreme Court)</span></td><td><span class="lang-ko"><strong>2026-06-11 — 원고 상고 기각, 상고비용 원고 부담. 피고 승소 취지로 최종 확정.</strong></span><span class="lang-en"><strong>2026-06-11 — the plaintiff's appeal was dismissed with costs against the plaintiff, confirming the outcome in the defendant's favour.</strong></span></td></tr>
+  </tbody>
+</table>
+<p class="lang-ko">대법원 판결로 본 사건의 통상적인 소송 절차는 종료되었습니다. 재단은 당사자가 아니나 2024년 관련 공시를 진행한 바 있어 투명한 정보 제공을 위해 후속 공시했습니다. 이에 따라 §10의 법적 리스크(R3) 평가를 하향 조정합니다. 원문: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-06-11_final-judgment-result_to_2024-01-29_litigation-disclosure.md" target="_blank" rel="noopener">공시 전문</a></p><p class="lang-en">The Supreme Court's judgment brings the ordinary course of proceedings in this case to an end. The Foundation is not a party, but because it made a related disclosure in 2024 it published a follow-up disclosure in the interest of transparency. Accordingly the legal risk assessment (R3) in §10 is revised downward. Full text: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-06-11_final-judgment-result_to_2024-01-29_litigation-disclosure.md" target="_blank" rel="noopener">the disclosure</a></p>
+
+<h3 id="s9.2">9.2 <span class="lang-ko">경영진 · 이사회 변동</span><span class="lang-en">Governance &amp; Board Changes</span></h3>
+<p class="lang-ko">2분기 중 공시 대상 경영진·이사회 변동은 없었던 것으로 파악됩니다.</p><p class="lang-en">No changes to management or the board requiring disclosure were identified during Q2.</p>
+
+<h3 id="s9.3">9.3 <span class="lang-ko">DAO 거버넌스 활동</span><span class="lang-en">DAO Governance Activity</span></h3>
+<div class="kpi">
+  <div class="cell"><div class="label">Q2 New Proposals</div><div class="value">0</div><div class="unit"><span class="lang-ko">직전 제안 2025-09-09</span><span class="lang-en">Previous proposal 2025-09-09</span></div></div>
+  <div class="cell"><div class="label">Cumulative Proposals</div><div class="value">41</div><div class="unit"><span class="lang-ko">누적 (2026-08-03 관측)</span><span class="lang-en">Cumulative (observed 2026-08-03)</span></div></div>
+  <div class="cell"><div class="label">Cumulative Votes</div><div class="value">304</div><div class="unit"><span class="lang-ko">누적 투표 수</span><span class="lang-en">Cumulative votes cast</span></div></div>
+  <div class="cell"><div class="label">Cumulative Voted MOC</div><div class="value">784,092</div><div class="unit"><span class="lang-ko">누적 투표량</span><span class="lang-en">Cumulative voting weight</span></div></div>
+</div>
+<p class="lang-ko">2분기 중 신규 거버넌스 제안은 <strong>0건</strong>입니다. 같은 기간 거버넌스의 <strong>참여 자격 인프라가 재구축</strong>되었습니다. 본 리포트는 두 사실을 함께 기록하되 <strong>제안 0건이 재정비 때문이라고 단정하지 않습니다</strong> — 거래소 보관 물량에는 투표권이 없다는 원칙 아래, 자가지갑 인증·위임 경로(Passport)와 인증 기반이 교체된 투표 플랫폼(Agora)이 이번 분기에 만들어졌습니다. 재정비 직후인 7/8, 이 인프라를 직접 활용하는 첫 제안 「MOC Activation Season 1 — 자가지갑 참여 전환 (90일 파일럿)」이 상정되었습니다(§12). 인프라 재정비가 실제 참여 회복으로 이어지는지는 3분기의 핵심 검증 항목입니다.</p><p class="lang-en">There were <strong>no</strong> new governance proposals in Q2. Over the same period the governance <strong>eligibility infrastructure was rebuilt</strong>. This report records both facts together but <strong>does not assert that the absence of proposals was caused by the rebuild</strong> — under the principle that balances held on exchanges carry no voting power, the self-custody authentication and delegation path (Passport) and a voting platform with replaced authentication foundations (Agora) were built this quarter. On 7/8, immediately after the rebuild, the first proposal drawing directly on that infrastructure — "MOC Activation Season 1 — transition to self-custody participation (90-day pilot)" — was tabled (§12). Whether the rebuild actually restores participation is a key item for verification in Q3.</p>
+
+<h3 id="s9.4">9.4 <span class="lang-ko">규제 환경 대응</span><span class="lang-en">Regulatory Environment</span></h3>
+<ul>
+  <li><span class="lang-ko"><strong>AI 기본법</strong> — 2026-01-22 시행된 AI 기본법·시행령에 따른 AI 생성물 표시 의무 환경에서, 재단은 2월 표시 정책 초안을 공개했으나 확정판 발행은 2분기 중 이루어지지 않았습니다(§1.2 항목 3). 본 리포트의 AI 보조 작성 고지(§B)는 초안 정책 기준으로 유지됩니다.</span><span class="lang-en"><strong>AI Framework Act</strong> — under the AI content labelling obligations arising from the AI Framework Act and its enforcement decree, effective 2026-01-22, the Foundation published a draft labelling policy in February but did not publish a final version during Q2 (§1.2 item 3). The AI authoring notice in this report (§B) therefore continues to follow the draft policy.</span></li>
+  <li><span class="lang-ko"><strong>가상자산이용자보호법 · DAXA 공통 공시</strong> — 2분기 중 재단에 새로 발생한 공시 의무 이슈는 파악되지 않았습니다. 유통량 변동(§2.7)은 공시 대시보드 사전 예고 체계로 관리됩니다.</span><span class="lang-en"><strong>Virtual Asset User Protection Act · DAXA common disclosure</strong> — no newly arising disclosure obligations for the Foundation were identified during Q2. Circulating supply changes (§2.7) are managed through the disclosure dashboard's advance-notice framework.</span></li>
+  <li><span class="lang-ko"><strong>정부 R&amp;D 과제</strong> — 2026-06-25 선정 발표 및 2026-07-10 협약 체결에 대한 후속 공시를 <strong>2026-08-04 발행</strong>했으며(MOSS-DISC-2026-0804 · §7.1 · §12), 수행 단계의 규제 요건 변동 발생 시에도 별도 공시 방침입니다.</span><span class="lang-en"><strong>Government R&amp;D project</strong> — the follow-up disclosure covering the 2026-06-25 selection announcement and the 2026-07-10 execution of the agreement was <strong>published on 2026-08-04</strong> (MOSS-DISC-2026-0804 · §7.1 · §12), and the policy remains to disclose separately should regulatory requirements change during the performance stage.</span></li>
+</ul>
+
+<h3 id="s9.5">9.5 <span class="lang-ko">최근 12개월 공식 공시 히스토리</span><span class="lang-en">Past 12 Months of Filings</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">시점</span><span class="lang-en">Date</span></th><th><span class="lang-ko">공시</span><span class="lang-en">Disclosure</span></th></tr></thead>
+  <tbody>
+    <tr><td>2025-11</td><td><span class="lang-ko">Mosscoin GOPAX 원화 마켓 상장 / Seoul:ution 2025 해커톤 공식 후원</span><span class="lang-en">MossCoin listed on the GOPAX KRW market / official sponsorship of the Seoul:ution 2025 hackathon</span></td></tr>
+    <tr><td>2025-12</td><td><span class="lang-ko">Mosscoin Luniverse MOC 소각 완료</span><span class="lang-en">MossCoin Luniverse MOC burn completed</span></td></tr>
+    <tr><td>2026-02</td><td><span class="lang-ko">2024-01-29 소송 공시 후속 — 2심 판결 결과</span><span class="lang-en">Follow-up to the 2024-01-29 litigation disclosure — second-instance judgment</span></td></tr>
+    <tr><td>2026-04</td><td><span class="lang-ko">AX Sprint R&amp;D 컨소시엄 참여 (제안 단계)</span><span class="lang-en">Participation in the AX Sprint R&amp;D consortium (proposal stage)</span></td></tr>
+    <tr><td>2026-06</td><td><span class="lang-ko">동 소송 후속 — 대법원 최종 판결 결과 (종결)</span><span class="lang-en">Further follow-up on the same litigation — Supreme Court final judgment (concluded)</span></td></tr>
+    <tr><td>2026-08</td><td><span class="lang-ko">AX Sprint 컨소시엄 과제 선정·협약 체결 후속 공시 (4/21 공시 후속 · 보고 기간 종료 후 발행)</span><span class="lang-en">Follow-up disclosure on the AX Sprint consortium project selection and execution of the agreement (follow-up to the 4/21 disclosure · published after the reporting period)</span></td></tr>
+  </tbody>
+</table>
+
+<!-- ================= §10 ================= -->
+<h2 class="section" id="s10"><span class="num">§10</span><span class="lang-ko">리스크 요인</span><span class="lang-en">Risk Factors</span></h2>
+<p class="lang-ko">1분기 리포트의 R1~R5 체계를 유지하되, 분기 중 변화를 반영해 방향(↑ 확대 · → 유지 · ↓ 축소)을 표기합니다.</p><p class="lang-en">The R1–R5 framework from the Q1 report is retained, with a direction marker (↑ increased · → unchanged · ↓ reduced) reflecting movement during the quarter.</p>
+
+<h3 id="s10.1">10.1 R1 — <span class="lang-ko">규제 리스크 (→ 유지)</span><span class="lang-en">Regulatory Risk</span></h3>
+<ul>
+  <li><span class="lang-ko">가상자산이용자보호법·DAXA 공통 공시 기준의 개정·범위 확대 가능성. 공시 항목 추가 시 리포트 구조를 재정비합니다.</span><span class="lang-en">Possible amendment or widening of the Virtual Asset User Protection Act and DAXA common disclosure standards. Should disclosure items be added, the report structure will be reorganised accordingly.</span></li>
+  <li><span class="lang-ko">AI 기본법 하위 기준(표시·워터마크 표준) 구체화에 따른 추가 의무 가능성 — AI 정책 확정판 발행(§13 이월 과제)으로 대응합니다.</span><span class="lang-en">Possible additional obligations as the subordinate standards of the AI Framework Act (labelling and watermarking) are specified — addressed by publishing the final AI policy (carried over in §13).</span></li>
+  <li><span class="lang-ko">글로벌 규제 분화(EU MiCA·EU AI Act 등)에 따른 지역별 서비스 접근 제한 가능성. 컨소시엄의 EU 파일럿 사이트 확장 시 해당 규제 검토가 선행됩니다.</span><span class="lang-en">Possible region-specific service restrictions as global regulation diverges (EU MiCA, EU AI Act and so on). Any expansion of the consortium's EU pilot site would be preceded by a review of those regimes.</span></li>
+</ul>
+
+<h3 id="s10.2">10.2 R2 — <span class="lang-ko">기술 리스크 (→ 유지 · 구성 변화)</span><span class="lang-en">Technology Risk</span></h3>
+<ul>
+  <li><span class="lang-ko">에이전트 실험 시스템의 오작동·환각·비용 초과 리스크 — LOCK/UNLOCK·예산 상한·감사 추적으로 통제 중이며, 2분기 AO에 도입된 DB 유실 대비 복원력 체계(v0.6.10 — 스키마 자가 복구·롤링 백업·무결성 검증)는 데이터 계층의 복원력이 실험 지속성의 전제라는 판단에서 나온 조치입니다(§7.4).</span><span class="lang-en">Risk of malfunction, hallucination and cost overrun in the agent experiment systems — controlled through LOCK/UNLOCK, budget ceilings and audit trails. The database-loss resilience introduced to AO in Q2 (v0.6.10 — schema self-healing, rolling backups, integrity checks) followed from the judgement that resilience at the data layer is a precondition for experiments continuing (§7.4).</span></li>
+  <li><span class="lang-ko"><strong>(신규 구성)</strong> 개발의 비공개 비중 확대(86.7%)에 따른 외부 검증 가능성 저하 — V1/V2/V3 등급 체계(§6.6)와 결과 서비스 공개(V2)로 완화하되, 구조적 한계는 §A.4에 기록합니다.</span><span class="lang-en"><strong>(newly added)</strong> Reduced external verifiability as the private share of development grew to 86.7% — mitigated by the V1/V2/V3 tier system (§6.6) and by publishing the resulting services (V2), with the structural limits recorded in §A.4.</span></li>
+  <li><span class="lang-ko">서비스 수 급증(분기 신규 8개)에 따른 유지보수 표면적 확대 — 자동 파이프라인화·배포 자동화·운영 인계 문서화로 대응 중이나, 소수 인력 대비 서비스 수는 운영 리스크 요인입니다(R5 연계).</span><span class="lang-en">A wider maintenance surface as the number of services grew sharply (8 new in the quarter) — addressed through automated pipelines, deployment automation and operational handover documentation, though the number of services relative to a small team remains an operational risk factor (linked to R5).</span></li>
+</ul>
+
+<h3 id="s10.3">10.3 R3 — <span class="lang-ko">법적 리스크 (↓ 하향)</span><span class="lang-en">Legal Risk</span></h3>
+<ul>
+  <li><span class="lang-ko">2024년 공시된 소송 트랙이 대법원 확정으로 종결되어(§9.1), 관련 불확실성이 해소되었습니다. 다만 이는 해당 사건에 한정되며, 일반적인 법적 리스크(신규 분쟁 가능성 등)는 상존합니다.</span><span class="lang-en">The litigation track disclosed in 2024 concluded with the Supreme Court's confirmation (§9.1), resolving the related uncertainty. This is limited to that case; general legal risk (the possibility of new disputes and so on) remains.</span></li>
+</ul>
+
+<h3 id="s10.4">10.4 R4 — <span class="lang-ko">시장 리스크 (↑ 확대)</span><span class="lang-en">Market Risk</span></h3>
+<ul>
+  <li><span class="lang-ko">분기말 시가총액은 직전 리포트 발행일(4/21) 스냅샷 대비 약 −38.5%, 가격은 52주 저점 부근입니다(§2.3 · 기준 시점 상이 — §2.8). 시장 급변 시 거래소 정책·유동성·커뮤니티 심리에 연쇄 영향이 가능합니다.</span><span class="lang-en">Quarter-end market capitalisation is about −38.5% against the snapshot as of the previous report's publication date (4/21), and the price is near the 52-week low (§2.3 · the reference points differ — §2.8). A sharp market move could have knock-on effects on exchange policy, liquidity and community sentiment.</span></li>
+  <li><span class="lang-ko">가격 변동은 재단이 직접 통제할 수 없는 외부 변수이며, 재단의 대응은 유통량 사전 예고(§2.7)·재단 지갑 상시 공개(§2.5)·분기 공시의 정직성 유지 등 신뢰 변수의 관리에 한정됩니다.</span><span class="lang-en">Price movement is an external variable the Foundation cannot control directly; the Foundation's response is limited to managing trust variables — advance notice of circulating-supply changes (§2.7), ongoing publication of the Foundation wallet (§2.5), and keeping the quarterly disclosure honest.</span></li>
+  <li><span class="lang-ko">외부 LLM 가격·접근성 악화 시 실험 시스템 비용 구조에 영향 — 로컬 모델 폴백·비용 상한(Alpha의 일일 LLM 비용 실링 등)으로 완화합니다.</span><span class="lang-en">Deterioration in external LLM pricing or availability would affect the cost structure of the experimental systems — mitigated by local model fallback and cost ceilings (such as Alpha's daily LLM cost cap).</span></li>
+</ul>
+
+<h3 id="s10.5">10.5 R5 — <span class="lang-ko">운영 · 조직 리스크 (→ 유지)</span><span class="lang-en">Operational Risk</span></h3>
+<ul>
+  <li><span class="lang-ko">분기 중 서비스 포트폴리오가 크게 늘어(§5) 소수 팀의 운영 부담이 증가했습니다. MAIT 통합 결정(§7.3)은 포트폴리오를 줄이는 방향의 첫 사례이며, "만들면 유지한다"가 아니라 "재평가 후 통합·종료를 선택지에 둔다"는 운영 규범이 도입되었습니다.</span><span class="lang-en">The service portfolio grew substantially during the quarter (§5), increasing the operational load on a small team. The decision to consolidate MAIT (§7.3) is the first case of reducing the portfolio, and introduces an operating norm of "reassess, and keep consolidation or retirement on the table" rather than "if we build it, we keep it".</span></li>
+  <li><span class="lang-ko">집계 파이프라인·공시 대시보드의 범위 불일치(§A.4)는 공시 신뢰에 대한 운영 리스크로, 3분기 정합화 과제로 관리합니다.</span><span class="lang-en">The scope mismatch between the aggregation pipeline and the disclosure dashboard (§A.4) is an operational risk to disclosure trust, managed as a Q3 reconciliation task.</span></li>
+</ul>
+
+<!-- ================= §11 ================= -->
+<h2 class="section" id="s11"><span class="num">§11</span><span class="lang-ko">분기 핵심 인사이트</span><span class="lang-en">Key Q2 Insights</span></h2>
+<ol>
+  <li><span class="lang-ko"><strong>실험은 주소를 얻을 때 책임이 생깁니다.</strong> 저장소 안의 실험도 인건비와 기회비용을 수반하지만 <strong>외부 사용자에 대한 운영 책임은 제한적입니다.</strong> 반면 <code>*.moss.land</code> 주소를 가진 서비스는 가용성·보안·정직한 라벨링(Algora의 시뮬레이션 데이터 표시 등)의 책임을 집니다. 2분기 커밋의 상당 부분이 기능이 아니라 이 책임(배포 자동화·백업·보안 헤더·접근성)에 쓰였고, 이는 실험 조직에서 운영 조직으로의 전환 비용입니다.</span><span class="lang-en"><strong>An experiment acquires responsibility when it acquires an address.</strong> Experiments inside a repository still carry personnel and opportunity costs, but <strong>the operational duty to outside users is limited.</strong> A service with a <code>*.moss.land</code> address, by contrast, carries duties of availability, security and honest labelling (such as Algora's marking of simulation data). A substantial share of Q2 commits went not into features but into those duties — deployment automation, backups, security headers, accessibility — and that is the cost of moving from an experimental organisation to an operating one.</span></li>
+  <li><span class="lang-ko"><strong>검증 가능성은 공개 코드만으로 확보되지 않습니다.</strong> 개발의 87%가 비공개로 이동한 분기에, 재단이 선택한 답은 "공개할 수 없는 것은 결과(서비스)와 등급(V1~V3)으로 검증받는다"입니다. 공개 커밋 목표 미달을 인정하고 지표를 재설계한 것(§1.2, §6.1)이 이 선택의 실행입니다.</span><span class="lang-en"><strong>Verifiability is not secured by public code alone.</strong> In a quarter when 87% of development moved into private repositories, the Foundation's answer was: "what cannot be opened is verified through the result (the service) and through a tier (V1–V3)". Acknowledging the missed public-commit target and redesigning the indicator (§1.2, §6.1) is that choice put into practice.</span></li>
+  <li><span class="lang-ko"><strong>거버넌스 공백기에 참여 인프라가 재구축되었습니다.</strong> 2분기에는 신규 제안이 0건이었고, 같은 기간 Passport·Agora의 참여 기반 재정비가 진행되었습니다 — 본 리포트는 두 사실을 함께 기록하되, 전자가 후자 때문이라고 단정하지는 않습니다. "거래소 보관 물량에는 투표권이 없다"는 원칙을 실제로 작동시키려면 자가지갑 인증·위임·보전 인프라가 먼저 필요했고, 그 인프라 완성 직후 첫 제안(7/8)이 상정되었습니다. 인프라가 참여를 실제로 회복시키는지가 3분기의 검증 항목입니다.</span><span class="lang-en"><strong>Participation infrastructure was rebuilt during a governance gap.</strong> Q2 saw no new proposals, and over the same period the participation foundations of Passport and Agora were rebuilt — this report records both facts together without asserting that the former was caused by the latter. Making the principle that "balances held on exchanges carry no voting power" actually work required self-custody authentication, delegation and reimbursement infrastructure first, and the first proposal (7/8) was tabled immediately after that infrastructure was completed. Whether the infrastructure actually restores participation is an item for verification in Q3.</span></li>
+  <li><span class="lang-ko"><strong>현실 신호는 이제 은유가 아닙니다.</strong> 1분기의 "Reality"는 아키텍처 다이어그램 속 계층이었지만, 2분기의 Reality는 CCTV 스트림·IoT GUID·재실 인원입니다. 디지털 트윈 트랙(1,086커밋)은 BRIDGE가 장기 목표로 삼는 "현실 신호 기반 거버넌스"의 데이터 원천을 만드는 작업이며, 컨소시엄(6/25 선정)은 이를 사업계획상의 국내·해외 실증 사이트로 확장하기 위한 <strong>계획상 경로</strong>이며, 과제 수행·실증 착수는 아직 진행 전입니다(§7.1).</span><span class="lang-en"><strong>Real-world signals are no longer a metaphor.</strong> Q1's "Reality" was a layer in an architecture diagram; Q2's Reality is CCTV streams, IoT GUIDs and occupancy counts. The digital twin track (1,086 commits) is the work of creating the data source for the "governance grounded in real-world signals" that BRIDGE holds as a long-term goal, and the consortium (selected 6/25) is a <strong>planned path</strong> for extending this to the domestic and overseas pilot sites in the business plan — project performance and the start of pilots have not yet begun (§7.1).</span></li>
+</ol>
+<p class="small lang-ko">위 인사이트는 분기 내부 관찰이며, 외부 제3자의 평가가 아닙니다. 각 인사이트의 근거는 인용된 섹션에서 확인하실 수 있습니다.</p><p class="small lang-en">The insights above are observations made within the quarter, not assessments by an external third party. The basis for each insight can be checked in the sections cited.</p>
+
+<!-- ================= §12 ================= -->
+<h2 class="section" id="s12"><span class="num">§12</span><span class="lang-ko">분기 이후 경과 (2026-07-01 ~ 데이터 스냅샷일)</span><span class="lang-en">Subsequent Events (2026-07-01 to the data snapshot date)</span></h2>
+<p class="lang-ko">보고 기간(4/1~6/30) 종료 후 데이터 스냅샷일(8/3)까지의 주요 사실입니다. 본 절의 내용은 2분기 KPI에 포함되지 않으며, 정식 집계·심층 서술은 3분기 리포트에서 다룹니다.</p><p class="lang-en">Material facts between the end of the reporting period (4/1–6/30) and the data snapshot date (8/3). Nothing in this section is included in the Q2 KPIs; formal counting and detailed narrative will follow in the Q3 report.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">날짜</span><span class="lang-en">Date</span></th><th><span class="lang-ko">경과</span><span class="lang-en">Development</span></th></tr></thead>
+  <tbody>
+    <tr><td>07-01 ~ 07-04</td><td><span class="lang-ko"><strong>MAIT 통합 실행</strong> — 현대화 완료(7/1) 후 거버넌스 연동 규격의 관리 주체를 Passport로 이관(7/2), AI 요약·이해 지원 기능을 Agora로 이전(7/3), Agora 측 MAIT 연동 제거(7/4). MAIT는 7월 초를 끝으로 운영 종료, 7/3 links 공식 목록에서 제외, 7/22 잔여 링크 정리.</span><span class="lang-en"><strong>MAIT consolidation executed</strong> — after modernisation completed (7/1), ownership of the governance integration specification moved to Passport (7/2), the AI summarisation and comprehension features moved to Agora (7/3), and Agora's MAIT integration was removed (7/4). MAIT was retired at the start of July, removed from the official links list on 7/3, with residual links cleaned up on 7/22.</span></td></tr>
+    <tr><td>07-05</td><td><span class="lang-ko">프로젝트 포털(<a href="https://github.com/mossland/Projects" target="_blank" rel="noopener">mossland/Projects</a>) README 전면 갱신 — Passport·Agora·Algora를 거버넌스 스택으로 묶어 정리, 종료된 MAIT 표기, 조직 이전으로 깨진 링크 수정. 공시 저장소 README·배너 정비 병행.</span><span class="lang-en">Full rewrite of the project portal README (<a href="https://github.com/mossland/Projects" target="_blank" rel="noopener">mossland/Projects</a>) — Passport, Agora and Algora grouped as the governance stack, MAIT marked as retired, and links broken by namespace moves repaired. The disclosure repository README and banner were tidied at the same time.</span></td></tr>
+    <tr><td>07-08</td><td><span class="lang-ko"><strong>신규 거버넌스 제안 상정</strong> — 「MOC Activation Season 1 — 자가지갑 참여 전환 (90일 파일럿)」. 2025-09 이후 첫 신규 제안이며, 2분기에 재구축된 참여 인프라(§7.2, §9.3)를 직접 활용하는 안건입니다. 상정 이틀간 약 109,000 MOC 투표 참여 관측. <span class="vb v1">V1</span></span><span class="lang-en"><strong>New governance proposal tabled</strong> — "MOC Activation Season 1 — transition to self-custody participation (90-day pilot)". It is the first new proposal since 2025-09 and draws directly on the participation infrastructure rebuilt in Q2 (§7.2, §9.3). About 109,000 MOC of voting participation was observed in the two days after tabling. <span class="vb v1">V1</span></span></td></tr>
+    <tr><td>07-08</td><td><span class="lang-ko"><strong>MOC Passport 소개 포스트 발행</strong> (KO/EN 페어) — 오픈베타(6/30) 8일 후, 위 거버넌스 제안과 같은 날 발행되었습니다. 서명 기반 보유 증명, 스탬프, 거버넌스 위임(ERC20Votes), 자가지갑 전환 비용 보전, Exit Pass의 설계 의도와 한계를 공개 서술했으며 — 보상 프로그램이 아니라는 점, 시그널 투표가 구속력 없는 참고 신호라는 점, Exit Pass가 아직 실제 실행 사례 없이 베타 상태라는 점을 포스트 자체에서 명시했습니다. <a href="https://medium.com/mossland-blog/moc-%ED%8C%A8%EC%8A%A4%ED%8F%AC%ED%8A%B8-%EB%B3%B4%EC%9C%A0%EA%B0%80-%EA%B2%80%EC%A6%9D-%EA%B0%80%EB%8A%A5%ED%95%9C-%EC%B0%B8%EC%97%AC%EA%B0%80-%EB%90%98%EB%8A%94-%EA%B3%B3-e38b29631a16" target="_blank" rel="noopener">KO</a> · <a href="https://medium.com/mossland-blog/moc-passport-where-holding-becomes-verifiable-participation-f37ad61623d6" target="_blank" rel="noopener">EN</a> <span class="vb v1">V1</span></span><span class="lang-en"><strong>MOC Passport introduction post published</strong> (KO/EN pair) — eight days after the open beta (6/30) and on the same day as the governance proposal above. It set out publicly the design intent and the limits of signature-based proof of holdings, stamps, governance delegation (ERC20Votes), reimbursement of self-custody transition costs and the Exit Pass — stating in the post itself that this is not a rewards programme, that signal votes are non-binding reference signals, and that the Exit Pass is still in beta with no actual execution case yet. <a href="https://medium.com/mossland-blog/moc-%ED%8C%A8%EC%8A%A4%ED%8F%AC%ED%8A%B8-%EB%B3%B4%EC%9C%A0%EA%B0%80-%EA%B2%80%EC%A6%9D-%EA%B0%80%EB%8A%A5%ED%95%9C-%EC%B0%B8%EC%97%AC%EA%B0%80-%EB%90%98%EB%8A%94-%EA%B3%B3-e38b29631a16" target="_blank" rel="noopener">KO</a> · <a href="https://medium.com/mossland-blog/moc-passport-where-holding-becomes-verifiable-participation-f37ad61623d6" target="_blank" rel="noopener">EN</a> <span class="vb v1">V1</span></span></td></tr>
+    <tr><td>07-10</td><td><span class="lang-ko"><strong>AX Sprint 컨소시엄 과제 협약 체결</strong> — 6/25 선정된 과제의 협약이 체결되었습니다. 재단의 비보상형·비지분형 지위에는 변동이 없으며, 정부 지원금은 재단으로 이전되지 않습니다(§7.1). <span class="vb v1">V1</span></span><span class="lang-en"><strong>Agreement executed for the AX Sprint consortium project</strong> — the agreement for the project selected on 6/25 was executed. The Foundation's non-compensatory, non-equity standing is unchanged, and no government funding is transferred to the Foundation (§7.1). <span class="vb v1">V1</span></span></td></tr>
+    <tr><td>07-15</td><td><span class="lang-ko">공시 저장소 README 서비스 목록 정비 — 종료·구형 항목(Wrapped MOC 베타 등) 제거, 이력 주석 정리.</span><span class="lang-en">Disclosure repository README service list tidied — retired and legacy entries (the Wrapped MOC beta and others) removed, historical notes cleaned up.</span></td></tr>
+    <tr><td>07-17 ~ 07-25</td><td><span class="lang-ko">조직 공통 문서 정비 — 보안 제보 채널을 <span class="mono">contact@moss.land</span>로 명시, 조직 기본 커뮤니티 문서 추가.</span><span class="lang-en">Common organisational documentation tidied — the security reporting channel stated as <span class="mono">contact@moss.land</span>, and baseline community documents added.</span></td></tr>
+    <tr><td>07-23</td><td><span class="lang-ko">Signal Map 소개 포스트 발행 (KO/EN 페어) — 2분기 공개 서비스의 소개 시리즈 지속.</span><span class="lang-en">Signal Map introduction post published (KO/EN pair) — continuing the introduction series for services published in Q2.</span></td></tr>
+    <tr><td>07-28 ~ 07-30</td><td><span class="lang-ko"><strong>StemFlow 공개</strong> (<a href="https://github.com/MosslandOpenDevs/stem_flow" target="_blank" rel="noopener">GitHub</a>) — 로컬 GPU 스템 분리·믹싱 스튜디오. BS-Roformer 2단 캐스케이드로 6개 스템(보컬·드럼·베이스·기타·피아노·other)을 분리하되 other를 원본−나머지 5개로 계산해 합산 시 원본이 무손실 복원되는 설계. Next.js + FastAPI, CUDA 완전 오프라인 추론. <span class="vb v1">V1</span></span><span class="lang-en"><strong>StemFlow published</strong> (<a href="https://github.com/MosslandOpenDevs/stem_flow" target="_blank" rel="noopener">GitHub</a>) — a local-GPU stem separation and mixing studio. A two-stage BS-Roformer cascade separates six stems (vocals, drums, bass, guitar, piano, other), with "other" computed as the original minus the other five so that summing the stems reconstructs the original losslessly. Next.js + FastAPI, fully offline CUDA inference. <span class="vb v1">V1</span></span></td></tr>
+    <tr><td><span class="lang-ko">7월 (집계)</span><span class="lang-en">July (aggregate)</span></td><td><span class="lang-ko">참여 인프라 개발 지속 — Passport 7월 중 v1.7.2 도달, Agora 기능 본편(제안 자격 기준·검색 요약·위임 투표권 반영), links 상태 실측 반영. 7월 커밋 수치는 3분기 리포트에서 §6.1 기준으로 공시합니다.</span><span class="lang-en">Participation infrastructure development continued — Passport reached v1.7.2 during July, Agora's main feature work landed (proposal eligibility criteria, search summaries, delegated voting power), and links status was updated against live checks. July commit figures will be disclosed on the §6.1 basis in the Q3 report.</span></td></tr>
+    <tr><td>08-01</td><td><span class="lang-ko">유통량 449,489,688 MOC — 공시 대시보드 예고분(8월 +1,000,000) 반영. 유통계획상 8/31 상한과 일치 <span class="vb v1">V1</span> / 3개 출처(CoinGecko·CoinMarketCap·재단 집계)가 일치하는 <strong>보고·추정값</strong> <span class="vb v2">V2</span>. 온체인 실현 전환은 미산출(§A.2).</span><span class="lang-en">Circulating supply 449,489,688 MOC — reflecting the +1,000,000 for August given advance notice on the disclosure dashboard. It matches the 8/31 ceiling under the supply plan <span class="vb v1">V1</span> and is the <strong>reported/estimated figure</strong> on which three sources agree (CoinGecko, CoinMarketCap and the Foundation's own count) <span class="vb v2">V2</span>. On-chain realised conversion is not computed (§A.2).</span></td></tr>
+    <tr><td><span class="lang-ko">스냅샷일 기준</span><span class="lang-en">As at the snapshot date</span></td><td><span class="lang-ko">Passport 오픈베타 초기 관측 — 인증 지갑 주소 9개 · 누적 스탬프 46 (서명의 벽 공개분 기준. 주소 수는 사람 수와 같지 않으며, 공개 미동의 서명은 포함되지 않음). 오픈베타 5주차의 초기값이며 3분기 리포트의 채택 지표 베이스라인이 됩니다. <span class="vb v1">V1</span></span><span class="lang-en">Initial observations from the Passport open beta — 9 verified wallet addresses · 46 cumulative stamps (based on what is published on the Wall of Signatures; the number of addresses is not the number of people, and signatures without consent to publication are excluded). These are week-five values of the open beta and become the baseline for adoption metrics in the Q3 report. <span class="vb v1">V1</span></span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><strong>※ 데이터 스냅샷일 이후 사실 — 발행일 기준으로 추가된 항목입니다.</strong> AX Sprint 선정 결과(2026-06-25 발표) 및 협약 체결(2026-07-10)에 대한 재단 후속 공시가 <strong>2026-08-04 발행</strong>되었습니다 — 문서번호 MOSS-DISC-2026-0804 (KO/EN). 데이터 스냅샷일(8/3) 기준으로는 미발행이었으며, 본 리포트 발행일에 맞춰 발행되었습니다. 공표(6/25)·협약(7/10)·발행(8/4)의 시점은 공시 본문 §5에 기재되어 있습니다(§7.1 · §1.2 항목 4). 원문: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up.pdf" target="_blank" rel="noopener">공시 PDF (KO)</a> · <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up_en.pdf" target="_blank" rel="noopener">EN</a></p><p class="small lang-en"><strong>※ A fact arising after the data snapshot date — added as at the publication date.</strong> The Foundation's follow-up disclosure on the AX Sprint selection (announced 2026-06-25) and the execution of the agreement (2026-07-10) was <strong>published on 2026-08-04</strong> — document number MOSS-DISC-2026-0804 (KO/EN). As at the data snapshot date (8/3) it was unpublished; it was published to coincide with this report's publication date. The dates of the announcement (6/25), the agreement (7/10) and publication (8/4) are recorded in §5 of the disclosure itself (§7.1 · §1.2 item 4). Originals: <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up.pdf" target="_blank" rel="noopener">Disclosure PDF (KO)</a> · <a href="https://github.com/mossland/Disclosure-and-Materials/blob/main/disclosures/2026/2026-08-04_ax-sprint-selection-and-agreement-follow-up_en.pdf" target="_blank" rel="noopener">EN</a></p>
+
+<!-- ================= §13 ================= -->
+<h2 class="section" id="s13"><span class="num">§13</span><span class="lang-ko">3분기 방향성 · 로드맵</span><span class="lang-en">Outlook · Q3 Roadmap</span></h2>
+<p class="lang-ko">아래 항목은 내부 목표이며, 실제 산출물과 일정은 외부 환경·규제 변화에 따라 변경될 수 있습니다 (§D 미래예측 진술 고지 참조).</p><p class="lang-en">The items below are internal targets; actual outputs and timing may change with the external environment and regulatory developments (see the forward-looking statements notice in §D).</p>
+
+<h3 id="s13.1">13.1 <span class="lang-ko">핵심 목표 (Q3)</span><span class="lang-en">Q3 Priorities</span></h3>
+<p class="lang-ko">2분기 스코어카드에서 정성 목표 5건 중 <strong>완전 달성은 없었고(부분 2 · 미달 3)</strong>, §10.5는 소수 팀의 운영 부담 증가를 리스크로 기록하고 있습니다. 이에 3분기 목표는 <strong>판정 대상 4건</strong>으로 통합했습니다. 이전 분기에 개별 항목으로 나열되던 측정·공시 정비 과제는 성격이 같으므로 <strong>하나의 프로그램(④)</strong>으로 묶었고, 성격상 달성·미달로 채점할 수 없는 항목은 아래 <strong>상시 운영 규범</strong>으로 분리해 판정 대상에서 제외했습니다.</p><p class="lang-en">On the Q2 scorecard, <strong>none of the five qualitative targets was fully met (2 partial · 3 missed)</strong>, and §10.5 records the increased operational load on a small team as a risk. Q3 targets are therefore consolidated to <strong>four assessable items</strong>. The measurement and disclosure clean-up tasks previously listed separately are of the same character and are grouped into <strong>a single programme (④)</strong>, while items that cannot sensibly be graded met/missed are separated out below as <strong>standing operating rules</strong> and excluded from assessment.</p>
+<ol>
+  <li><span class="lang-ko"><strong>Passport 채택 지표 공식 집계 개시</strong> — 인증 지갑·월간 체크인·위임 수를 분기 리포트 정식 지표로 편입. 서명의 벽 공개 데이터와 일치 검증.</span><span class="lang-en"><strong>Begin official counting of Passport adoption metrics</strong> — bring verified wallets, monthly check-ins and delegations into the quarterly report as formal indicators, verified against the public Wall of Signatures data.</span></li>
+  <li><span class="lang-ko"><strong>Agora 기능 본편 완료·정착</strong> — 제안 자격 기준·위임 투표권 반영을 포함한 갱신 완료, 7/8 파일럿 제안의 결과 공시.</span><span class="lang-en"><strong>Complete and embed Agora's main feature work</strong> — finish the update including proposal eligibility criteria and delegated voting power, and disclose the outcome of the 7/8 pilot proposal.</span></li>
+  <li><span class="lang-ko"><strong>AI 활용 정책 확정판 발행</strong> (Q2 이월) — 2월 초안의 확정 버전 발행 및 재단 발행물 적용.</span><span class="lang-en"><strong>Publish the final AI usage policy</strong> (carried over from Q2) — publish the final version of the February draft and apply it to Foundation publications.</span></li>
+  <li><span class="lang-ko"><strong>공시 · 집계 체계 정비</strong> (통합 과제) — 아래 네 산출물을 하나의 과제로 관리합니다. <strong>채점 규칙: 네 산출물을 모두 완료하면 달성, 1~3개 완료면 부분, 0개면 미달로 판정합니다.</strong></span><span class="lang-en"><strong>Disclosure and counting framework clean-up</strong> (consolidated task) — the four deliverables below are managed as a single task. <strong>Grading rule: all four complete = Met, one to three complete = Partial, none complete = Missed.</strong></span>
+    <ul>
+      <li><span class="lang-ko"><strong>집계 정합화</strong> — 공시 대시보드의 개발 지표 추적 범위를 §6.1 기준과 일치시킵니다. 2회 이월된 <strong>외부 기여자·PR 지표는 자동 집계 파이프라인 구축을 보류</strong>합니다 — 2분기 공개 저장소 PR은 19건(작성자 3명)이고 그중 <strong>조직 외부 기여자의 PR은 1건</strong>이었습니다. 분기 1건 수준의 지표를 위해 파이프라인을 만드는 것은 현 단계에서 실익이 없습니다. 대신 <strong>공개 PR 총수 · 고유 작성자 수 · 조직 외부 기여자 PR 수를 수동 집계해 분기 설명 지표로 공시</strong>하며, 외부 기여가 유의미한 규모가 되면 자동화를 도입합니다(§8.3). <span class="vb v1">V1</span></span><span class="lang-en"><strong>Reconcile the counting basis</strong> — bring the disclosure dashboard's development-metric scope into line with §6.1. For the twice-carried-over <strong>external contributor and PR metrics, building the automated aggregation pipeline is deferred</strong> — Q2 saw 19 PRs in public repositories from 3 authors, of which <strong>1 PR came from a contributor outside the organisation</strong>. Building a pipeline for a metric of that size serves no practical purpose at this stage. Instead, <strong>total public PRs, distinct authors and PRs from contributors outside the organisation will be counted manually and disclosed as quarterly descriptive indicators</strong>, with automation introduced once external contribution reaches a meaningful scale (§8.3). <span class="vb v1">V1</span></span></li>
+      <li><span class="lang-ko"><strong>에이전트 결정 사례 정의 고정</strong> — &ldquo;관찰 가능한 결정 사례&rdquo;의 정의를 §6.1 수준으로 고정하고 판정 재개.</span><span class="lang-en"><strong>Fix the definition of agent decision cases</strong> — fix the definition of an "observable decision case" to the standard of §6.1 and resume assessment.</span></li>
+      <li><span class="lang-ko"><strong>실험 서비스 가동 상태 공개</strong> — <code>*.moss.land</code> 실험 서비스(AO·Algora·BRIDGE 등)의 가동 여부를 외부에서 판별할 수 있는 상태 지표(최근 처리 시각·최근 24시간 처리량 등) 공개. 누적 수치만으로는 가동 여부를 판별할 수 없다는 점이 본 리포트 작성 중 확인되었습니다.</span><span class="lang-en"><strong>Publish operational status for the experimental services</strong> — publish status indicators (last processing time, throughput over the past 24 hours and so on) by which anyone outside can tell whether the <code>*.moss.land</code> experimental services (AO, Algora, BRIDGE and others) are running. It was confirmed while preparing this report that cumulative figures alone cannot establish whether a pipeline is running.</span></li>
+      <li><span class="lang-ko"><strong>온체인 기준 실현 유통량 산출</strong> — 기준 블록·비유통 지갑 잔액·전환 트랜잭션으로 산출해 §A.2의 ③을 채웁니다(§A.4).</span><span class="lang-en"><strong>Compute on-chain realised circulating supply</strong> — compute it from a reference block, non-circulating wallet balances and conversion transactions, filling in ③ of §A.2 (§A.4).</span></li>
+    </ul></li>
+</ol>
+
+<h4><span class="lang-ko">Q3 목표별 완료 증거</span><span class="lang-en">Completion evidence for each Q3 target</span></h4>
+<table>
+  <thead><tr><th><span class="lang-ko">과제</span><span class="lang-en">Task</span></th><th><span class="lang-ko">완료 증거 (다음 분기 스코어카드 판정 근거)</span><span class="lang-en">Completion evidence (the basis for next quarter's scorecard assessment)</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">① Passport 채택 지표 집계 개시</span><span class="lang-en">① Begin counting Passport adoption metrics</span></td><td><span class="lang-ko">3분기 리포트 정식 지표 등재 + 서명의 벽 공개 데이터와의 대조표</span><span class="lang-en">Formal indicators entered in the Q3 report + a reconciliation table against the public Wall of Signatures data</span></td></tr>
+    <tr><td><span class="lang-ko">② Agora 기능 본편 완료·정착</span><span class="lang-en">② Complete and embed Agora's main feature work</span></td><td><span class="lang-ko">제안 자격 기준·위임 투표권이 반영된 라이브 서비스 + 7/8 제안 결과 공시</span><span class="lang-en">A live service reflecting proposal eligibility criteria and delegated voting power + disclosure of the 7/8 proposal's outcome</span></td></tr>
+    <tr><td><span class="lang-ko">③ AI 활용 정책 확정판 발행</span><span class="lang-en">③ Publish the final AI usage policy</span></td><td><span class="lang-ko">버전이 표기된 확정 문서의 공개 URL + 재단 발행물 적용 사례</span><span class="lang-en">A public URL for the version-stamped final document + a case of it applied to a Foundation publication</span></td></tr>
+    <tr><td><span class="lang-ko">④-1 집계 정합화</span><span class="lang-en">④-1 Reconcile the counting basis</span></td><td><span class="lang-ko">대시보드와 리포트가 동일 데이터셋을 참조함을 보이는 대조표</span><span class="lang-en">A reconciliation table showing that the dashboard and the report reference the same dataset</span></td></tr>
+    <tr><td><span class="lang-ko">④-2 에이전트 결정 사례 정의 고정</span><span class="lang-en">④-2 Fix the definition of agent decision cases</span></td><td><span class="lang-ko">정의 문서 + 해당 정의로 집계한 표본</span><span class="lang-en">A definition document + a sample counted under that definition</span></td></tr>
+    <tr><td><span class="lang-ko">④-3 실험 서비스 가동 상태 공개</span><span class="lang-en">④-3 Publish operational status for the experimental services</span></td><td><span class="lang-ko">외부에서 접근 가능한 상태 엔드포인트 또는 대시보드 항목</span><span class="lang-en">An externally reachable status endpoint or dashboard item</span></td></tr>
+    <tr><td><span class="lang-ko">④-4 온체인 실현 유통량 산출</span><span class="lang-en">④-4 Compute on-chain realised circulating supply</span></td><td><span class="lang-ko">기준 블록 · 지갑 목록 · 산식과 그 결과값</span><span class="lang-en">The reference block · wallet list · formula and the resulting figure</span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko">본 표는 <strong>무엇이 있으면 완료로 보는지</strong>만 정의합니다. 담당과 기한은 두지 않습니다 — 분기 목표의 기한은 분기말이고, 달성 여부는 <strong>3분기 리포트의 스코어카드가 그대로 판정</strong>하기 때문입니다. 완료 증거를 미리 못박아 두는 것은 &ldquo;대체로 했다&rdquo;는 자기신고를 막기 위한 것으로, 각 항목은 <strong>외부가 확인할 수 있는 산출물</strong>로 정의했습니다.</p><p class="small lang-en">This table defines only <strong>what has to exist for an item to count as complete</strong>. It assigns no owner and no deadline — the deadline for a quarterly target is quarter-end, and whether it was met is <strong>assessed by the Q3 report's scorecard itself</strong>. Fixing the completion evidence in advance is meant to preclude a self-reported "broadly done", so each item is defined as <strong>an output that can be checked from outside</strong>.</p>
+
+<h4><span class="lang-ko">상시 운영 규범 (판정 대상 아님)</span><span class="lang-en">Standing operating rules (not assessed)</span></h4>
+<p class="lang-ko">아래 두 항목은 분기 목표가 아니라 <strong>발효된 운영 규범</strong>입니다. 달성·미달로 채점하지 않으며, 위반 사례가 발생하면 해당 분기 리포트에 기재합니다.</p><p class="lang-en">The two items below are not quarterly targets but <strong>operating rules already in force</strong>. They are not graded met/missed; where a breach occurs it is recorded in that quarter's report.</p>
+<ul>
+  <li><span class="lang-ko"><strong>공시 예고 이행 절차</strong> — (1) 후속 공시를 예고하는 공시는 발행 시점에 예고 항목·트리거 사건·담당·기한을 공시 관리 목록에 등록, (2) 정부 과제·외부 협력 건은 공표·협약 체결·착수 시점을 사전에 트리거로 고정, (3) 분기 리포트에서 예고된 공시 항목의 이행 여부를 전수 점검. 아울러 <strong>외부 사건(정부 발표 등)에 종속되는 목표</strong>는 분기 경계만으로 판정하면 재단이 통제할 수 없는 시점에 결과가 좌우되므로, <strong>트리거 사건과 그로부터의 대응 기한을 함께 정의</strong>해 제시합니다. 과제 수행 단계의 실증 마일스톤도 같은 기준으로 공시합니다(§7.1 · MOSS-DISC-2026-0804).</span><span class="lang-en"><strong>Procedure for honouring promised disclosures</strong> — (1) any disclosure that promises a follow-up registers, at the time of its publication, the promised item, its triggering event, an assigned owner and a deadline in the disclosure tracking list; (2) for government projects and external collaborations, the announcement, agreement execution and project commencement dates are fixed in advance as triggers; (3) each quarterly report reviews every promised disclosure item for fulfilment. In addition, because a <strong>target dependent on an external event (a government announcement, for example)</strong> would be decided by timing the Foundation cannot control if assessed on the quarter boundary alone, such targets will be stated <strong>with both the triggering event and a response deadline measured from it</strong>. Pilot milestones during project performance are disclosed on the same basis (§7.1 · MOSS-DISC-2026-0804).</span></li>
+  <li><span class="lang-ko"><strong>서비스 공개 ↔ 커뮤니케이션 동기화</strong> — 2분기 공개 서비스(Passport 등)의 소개 포스트가 분기 종료 후에 발행된 사례를 반영해, 신규 서비스 공개 시 동일 분기 내 소개 포스트 발행을 원칙으로 고정합니다(§4.1 · §12).</span><span class="lang-en"><strong>Synchronise service launches with communication</strong> — reflecting the case in Q2 where the introduction post for a published service (Passport) appeared after quarter-end, publishing an introduction post within the same quarter as any new service launch is fixed as a rule (§4.1 · §12).</span></li>
+</ul>
+
+<h3 id="s13.2">13.2 <span class="lang-ko">2026년 로드맵 (간트)</span><span class="lang-en">2026 Roadmap</span></h3>
+<div class="gantt">
+  <div class="q"><span>Q1</span><span>Q2</span><span>Q3</span><span>Q4</span></div>
+  <div class="row"><div class="l"><span class="lang-ko">디지털 트윈 · Physical AI</span><span class="lang-en">Digital twin · Physical AI</span></div><div class="track"><div class="seg c3" style="left:0;width:25%">PoC slice</div><div class="seg" style="left:25%;width:25%">engine + live building</div><div class="seg c2" style="left:50%;width:50%">H2 — pilot expansion · consortium selected</div></div></div>
+  <div class="row"><div class="l"><span class="lang-ko">홀더 참여 인프라</span><span class="lang-en">Holder participation infrastructure</span></div><div class="track"><div class="seg c3" style="left:25%;width:25%"><span class="lang-ko">Passport v1 · Agora 재정비</span><span class="lang-en">Passport v1 · Agora rebuild</span></div><div class="seg" style="left:50%;width:25%">adoption metrics · Season 1</div><div class="seg c2" style="left:75%;width:25%">iterate</div></div></div>
+  <div class="row"><div class="l"><span class="lang-ko">에이전트 거버넌스 실험</span><span class="lang-en">Agent governance experiments</span></div><div class="track"><div class="seg c3" style="left:0;width:50%">build · publish</div><div class="seg" style="left:50%;width:50%">resume ingest · case accounting</div></div></div>
+  <div class="row"><div class="l"><span class="lang-ko">AI 미디어 클러스터</span><span class="lang-en">AI media cluster</span></div><div class="track"><div class="seg c3" style="left:25%;width:25%">build sprint</div><div class="seg c2" style="left:50%;width:50%">automated ops · adoption TBD</div></div></div>
+  <div class="row"><div class="l"><span class="lang-ko">AI 콘텐츠 표시 정책</span><span class="lang-en">AI content labelling policy</span></div><div class="track"><div class="seg c3" style="left:0;width:50%">draft</div><div class="seg" style="left:50%;width:25%">Q3 finalize (carried over)</div><div class="seg c2" style="left:75%;width:25%">apply</div></div></div>
+  <div class="row"><div class="l"><span class="lang-ko">공시 체계 · 집계 정합화</span><span class="lang-en">Disclosure framework · counting reconciliation</span></div><div class="track"><div class="seg c3" style="left:0;width:50%">V-tiers · wallet disclosure</div><div class="seg" style="left:50%;width:50%">dashboard ↔ report alignment</div></div></div>
+  <div class="row"><div class="l"><span class="lang-ko">디지털 트윈 R&amp;D 컨소시엄</span><span class="lang-en">Digital twin R&amp;D consortium</span></div><div class="track"><div class="seg ghost" style="left:25%;width:75%"><span class="lang-ko">6/25 선정 · 7/10 협약 · 8/4 후속 공시 → 실증 마일스톤</span><span class="lang-en">6/25 selected · 7/10 agreement · 8/4 disclosure → pilots</span></div></div></div>
+</div>
+<p class="small lang-ko">간트는 내부 목표 기준이며 계약적 약속이 아닙니다. 빗금(ghost) 막대는 외부 협력·규제 일정에 연동되어 유동적인 항목입니다.</p><p class="small lang-en">The Gantt chart reflects internal targets and is not a contractual commitment. Hatched (ghost) bars are items that remain fluid because they depend on external collaboration or regulatory timelines.</p>
+
+<h3 id="s13.3">13.3 <span class="lang-ko">주요 지표 (Q3 끝 기준)</span><span class="lang-en">Target Indicators</span></h3>
+<p class="lang-ko">지표는 <strong>목표</strong>(판정 대상)와 <strong>설명 지표</strong>(추세 관찰용, 판정 대상 아님)로 구분합니다. 커밋 수는 이력 이관·병합·자동 생성으로 값이 움직이며, 이번 분기에도 기준 불일치로 목표 판정에 재집계가 필요했습니다(§1.2 · §A.3). 따라서 <strong>커밋 수를 목표에서 설명 지표로 강등</strong>하고, 개발 활동은 결과물(서비스·공시·릴리스)로 판정합니다.</p><p class="lang-en">Indicators are split into <strong>targets</strong> (assessed) and <strong>descriptive indicators</strong> (for observing trends, not assessed). Commit counts move with history imports, merges and automated generation, and this quarter a recount was again needed to settle a target assessment because the bases differed (§1.2 · §A.3). Commit counts are therefore <strong>demoted from targets to descriptive indicators</strong>, and development activity is assessed by its outputs (services, disclosures, releases).</p>
+<table>
+  <thead><tr><th><span class="lang-ko">지표</span><span class="lang-en">Indicator</span></th><th><span class="lang-ko">구분</span><span class="lang-en">Type</span></th><th><span class="lang-ko">Q2 실적</span><span class="lang-en">Q2 actual</span></th><th><span class="lang-ko">Q3 기준</span><span class="lang-en">Q3 basis</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">공식 공시</span><span class="lang-en">Official disclosures</span></td><td><span class="lang-ko">목표</span><span class="lang-en">Target</span></td><td>2</td><td><span class="lang-ko">이슈 발생 시 즉시 (정량 목표 없음)</span><span class="lang-en">Immediately upon an issue arising (no quantitative target)</span></td></tr>
+    <tr><td><span class="lang-ko">Medium 포스트</span><span class="lang-en">Medium posts</span></td><td><span class="lang-ko">목표</span><span class="lang-en">Target</span></td><td>19 <span class="lang-ko">(페어 7)</span><span class="lang-en">(7 pairs)</span></td><td><span class="lang-ko">≥ 6 (KO/EN 페어 ≥ 4)</span><span class="lang-en">≥ 6 (KO/EN pairs ≥ 4)</span></td></tr>
+    <tr><td><span class="lang-ko">총 커밋 (3개 GitHub 네임스페이스 · §6.1 기준)</span><span class="lang-en">Total commits (three GitHub namespaces · §6.1 basis)</span></td><td><span class="muted lang-ko">설명 지표</span><span class="muted lang-en">Descriptive indicator</span></td><td>1,945</td><td><span class="lang-ko">수치 목표 없음 — §6.1 기준(기본 브랜치·저자일·병합 포함)을 동일하게 유지해 추세만 공시</span><span class="lang-en">No numeric target — the §6.1 basis (default branch, author date, merges included) is kept constant and only the trend is disclosed</span></td></tr>
+    <tr><td><span class="lang-ko">공개 커밋</span><span class="lang-en">Public commits</span></td><td><span class="muted lang-ko">설명 지표</span><span class="muted lang-en">Descriptive indicator</span></td><td>259 <span class="muted"><span class="lang-ko">(전 브랜치 273)</span><span class="lang-en">(273 across all branches)</span></span></td><td><span class="lang-ko">수치 목표 없음 — 공개 저장소 비중은 결과물 공개(서비스·문서)로 판단</span><span class="lang-en">No numeric target — the share of public repositories is judged by published outputs (services, documents)</span></td></tr>
+    <tr><td><span class="lang-ko">Passport 인증 지갑</span><span class="lang-en">Passport verified wallets</span></td><td><span class="lang-ko">목표</span><span class="lang-en">Target</span></td><td><span class="lang-ko">베이스라인 9 (§12)</span><span class="lang-en">Baseline 9 (§12)</span></td><td><span class="lang-ko">공식 집계 개시 + 성장 공시 (수치 목표는 집계 1분기 경과 후 설정)</span><span class="lang-en">Begin official counting + disclose growth (a numeric target will be set after one quarter of counting)</span></td></tr>
+    <tr><td><span class="lang-ko">관찰 가능한 에이전트 결정 사례</span><span class="lang-en">Observable agent decision cases</span></td><td><span class="lang-ko">목표</span><span class="lang-en">Target</span></td><td><span class="lang-ko">판정 유보</span><span class="lang-en">Assessment deferred</span></td><td><span class="lang-ko">정의 고정 후 ≥ 10 재판정</span><span class="lang-en">≥ 10, reassessed once the definition is fixed</span></td></tr>
+  </tbody>
+</table>
+
+<h3 id="s13.4">13.4 <span class="lang-ko">단기 시나리오 (Q3)</span><span class="lang-en">Near-Term Scenarios</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">시나리오</span><span class="lang-en">Scenario</span></th><th><span class="lang-ko">트리거</span><span class="lang-en">Trigger</span></th><th><span class="lang-ko">대응 방향</span><span class="lang-en">Response</span></th></tr></thead>
+  <tbody>
+    <tr><td>Base</td><td><span class="lang-ko">규제·시장 변동성 안정 범위 내</span><span class="lang-en">Regulatory and market volatility within a stable range</span></td><td><span class="lang-ko">§13.1 목표 일정 준수</span><span class="lang-en">Keep to the target schedule in §13.1</span></td></tr>
+    <tr><td>Upside</td><td><span class="lang-ko">선정 과제의 실증 순조 진행 (협약 2026-07-10 체결 완료)</span><span class="lang-en">Pilots for the selected project proceed smoothly (agreement executed 2026-07-10)</span></td><td><span class="lang-ko">실증 마일스톤 공시 신속 발행 + 디지털 트윈 트랙 공개 범위 확대 검토</span><span class="lang-en">Publish pilot milestones promptly + consider widening what is published from the digital twin track</span></td></tr>
+    <tr><td>Downside</td><td><span class="lang-ko">시장 추가 악화 또는 외부 LLM 비용·접근성 악화</span><span class="lang-en">Further market deterioration, or worsening external LLM cost and availability</span></td><td><span class="lang-ko">로컬 모델 비중 확대·실험 시스템 축소 운영, 유통 계획 재검토 시 사전 공시</span><span class="lang-en">Increase reliance on local models and scale back the experimental systems; disclose in advance if the supply plan is reconsidered</span></td></tr>
+    <tr><td>Contingency</td><td><span class="lang-ko">규제·법적 변수 발생</span><span class="lang-en">A regulatory or legal development arises</span></td><td><span class="lang-ko">즉시 공식 공시 채널 고지, 해당 섹션 즉시 반영</span><span class="lang-en">Notify immediately through the official disclosure channels and update the relevant section at once</span></td></tr>
+  </tbody>
+</table>
+
+<!-- ================= APPENDICES ================= -->
+<h2 class="section" id="appA"><span class="num">§A</span><span class="lang-ko">데이터 출처 및 방법론</span><span class="lang-en">Sources &amp; Methodology</span></h2>
+
+<h3>A.1 <span class="lang-ko">주 데이터 출처</span><span class="lang-en">Primary Sources</span></h3>
+<table>
+  <thead><tr><th><span class="lang-ko">영역</span><span class="lang-en">Area</span></th><th><span class="lang-ko">출처</span><span class="lang-en">Source</span></th><th><span class="lang-ko">등급</span><span class="lang-en">Tier</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">개발 활동</span><span class="lang-en">Development activity</span></td><td><span class="lang-ko">GitHub API — 3개 GitHub 네임스페이스 93개 저장소, 기본 브랜치·작성일 기준 (§6.1)</span><span class="lang-en">GitHub API — 93 repositories across three GitHub namespaces, default branch and author date (§6.1)</span></td><td><span class="vb v1">V1</span> <span class="lang-ko">(공개분)</span><span class="lang-en">(public)</span> · <span class="vb v3">V3</span> <span class="lang-ko">(비공개분)</span><span class="lang-en">(private)</span></td></tr>
+    <tr><td><span class="lang-ko">시장 지표</span><span class="lang-en">Market indicators</span></td><td><span class="lang-ko">CoinGecko(분기말 시점) · CoinMarketCap·재단 집계(현재값 교차) · Upbit(가격 범위)</span><span class="lang-en">CoinGecko (as at quarter-end) · CoinMarketCap and the Foundation's own count (cross-check of current values) · Upbit (price range)</span></td><td><span class="vb v1">V1</span></td></tr>
+    <tr><td><span class="lang-ko">유통량 — 계획 상한</span><span class="lang-en">Circulating supply — plan ceiling</span></td><td><span class="lang-ko">2025-01-09 공시 「MOC 유통계획」(월말 기준) · disclosure.moss.land Supply Plan</span><span class="lang-en">The 2025-01-09 disclosure "MOC Supply Plan" (month-end basis) · disclosure.moss.land Supply Plan</span></td><td><span class="vb v1">V1</span></td></tr>
+    <tr><td><span class="lang-ko">유통량 — 보고·추정</span><span class="lang-en">Circulating supply — reported/estimated</span></td><td><span class="lang-ko">CoinGecko 시가총액÷가격 역산 · CoinMarketCap·재단 집계 교차</span><span class="lang-en">CoinGecko market cap ÷ price, back-calculated · cross-checked against CoinMarketCap and the Foundation's own count</span></td><td><span class="vb v2">V2</span></td></tr>
+    <tr><td><span class="lang-ko">유통량 — 온체인 실현</span><span class="lang-en">Circulating supply — on-chain realised</span></td><td><span class="lang-ko"><strong>본 리포트 미산출</strong> — 산출 시 Etherscan(재단 지갑 공개) 기준 블록·비유통 지갑 잔액·전환 트랜잭션 필요(§A.4)</span><span class="lang-en"><strong>Not computed in this report</strong> — computing it would require a reference block, non-circulating wallet balances and conversion transactions on Etherscan (Foundation wallets published) (§A.4)</span></td><td><span class="muted">—</span></td></tr>
+    <tr><td><span class="lang-ko">거버넌스</span><span class="lang-en">Governance</span></td><td><span class="lang-ko">agora.moss.land · 공시 대시보드 DAO 섹션</span><span class="lang-en">agora.moss.land · the DAO section of the disclosure dashboard</span></td><td><span class="vb v1">V1</span></td></tr>
+    <tr><td><span class="lang-ko">커뮤니케이션</span><span class="lang-en">Communication</span></td><td><span class="lang-ko">Medium 발행 아카이브 전수 확인(2026-08-04 · 발행 관리 화면 기준) · Disclosure-and-Materials 저장소. RSS 단독 수집은 롤링 창 밖의 분기 초 발행분을 누락시켜 분기 집계 기준에서 제외했습니다.</span><span class="lang-en">Full review of the Medium publication archive (2026-08-04, from the publication management screen) · the Disclosure-and-Materials repository. Collecting via RSS alone misses posts published early in the quarter that fall outside the rolling window, so it was excluded as a basis for quarterly counting.</span></td><td><span class="vb v1">V1</span></td></tr>
+    <tr><td><span class="lang-ko">프로젝트 서술</span><span class="lang-en">Project narratives</span></td><td><span class="lang-ko">각 프로젝트 팀 제출 요약 + 저장소 커밋 로그 기반 재구성. 비공개 트랙은 저장소 단위가 아닌 워크스트림 단위로만 기술</span><span class="lang-en">Summaries submitted by each project team + reconstruction from repository commit logs. Private tracks are described only at workstream level, never per repository</span></td><td><span class="vb v2">V2</span>/<span class="vb v3">V3</span></td></tr>
+  </tbody>
+</table>
+
+<h3>A.2 <span class="lang-ko">집계 규칙 요약</span><span class="lang-en">Counting Rules</span></h3>
+<ul>
+  <li><span class="lang-ko">커밋: 기본 브랜치 · 작성일(author date) 기준 · 병합 커밋 포함 · <strong>UTC 기준</strong> 2026-04-01T00:00Z ~ 07-01T00:00Z (KST 기준 분기 경계와 9시간 차이가 있으며, 본 리포트는 UTC로 통일합니다) (§6.1). 공개 저장소 수치는 GitHub API로 재현 가능.</span><span class="lang-en">Commits: default branch · author date · merge commits included · <strong>UTC</strong> 2026-04-01T00:00Z to 07-01T00:00Z (nine hours apart from the KST quarter boundary; this report standardises on UTC) (§6.1). Public repository figures are reproducible via the GitHub API.</span></li>
+  <li><span class="lang-ko">블로그: 포스트 단위 집계(KO/EN 각 1건). 동일 주제의 KO/EN 동일일 발행을 "페어"로 별도 집계.</span><span class="lang-en">Blog: counted per post (KO and EN count as one each). Same-topic KO/EN posts published on the same day are separately counted as a "pair".</span></li>
+  <li><span class="lang-ko">시장: 분기말(6/30) 스냅샷 primary. <strong>유통량은 세 층으로 구분해 읽어야 합니다.</strong><br>① <strong>유통계획상 월말 최대 유통 가능 수량</strong> = 448,489,688 — 2025-01-09 공시 원문 기준 <span class="vb v1">V1</span><br>② <strong>보고·추정 유통량</strong> = 448,489,688 — CoinGecko 시가총액÷가격 역산. ①과 일치하나 시가총액이 공급량으로 산출되므로 순환 참조 가능성이 있습니다 <span class="vb v2">V2</span><br>③ <strong>온체인 기준 실현 유통량</strong> = <strong>본 리포트 미산출</strong> — 기준 블록·비유통 지갑 잔액·전환 트랜잭션으로 산출해야 하며 §A.4의 후속 과제입니다<br>①과 ②의 일치는 <strong>보고값의 정합성</strong>을 높이지만 <strong>독립적인 온체인 검증은 아닙니다.</strong> 본 리포트가 제시하는 분기말 유통량은 ②이며 등급은 V2입니다.</span><span class="lang-en">Market: the quarter-end (6/30) snapshot is primary. <strong>Circulating supply must be read as three distinct layers.</strong><br>① <strong>Month-end maximum permitted circulating supply under the supply plan</strong> = 448,489,688 — per the text of the 2025-01-09 disclosure <span class="vb v1">V1</span><br>② <strong>Reported/estimated circulating supply</strong> = 448,489,688 — back-calculated from CoinGecko market cap ÷ price. It agrees with ①, but because market cap is itself derived from supply there is scope for circular reference <span class="vb v2">V2</span><br>③ <strong>On-chain realised circulating supply</strong> = <strong>not computed in this report</strong> — it requires a reference block, non-circulating wallet balances and conversion transactions, and is a follow-up task in §A.4<br>Agreement between ① and ② strengthens the <strong>internal consistency of the reported figure</strong> but <strong>is not independent on-chain verification.</strong> The quarter-end circulating supply this report presents is ②, at tier V2.</span></li>
+  <li><span class="lang-ko">서비스 수: links.moss.land 등재 기준 + 라이브 접근 확인.</span><span class="lang-en">Service count: entries listed on links.moss.land + a live access check.</span></li>
+</ul>
+
+
+<h3>A.3 <span class="lang-ko">재현 매니페스트</span><span class="lang-en">Reproduction Manifest</span></h3>
+<p class="lang-ko">본 절은 본 리포트 작성 과정에서 <strong>실제로 수행한 재집계</strong>의 절차와 결과를 기록합니다(데이터 스냅샷 2026-08-03 · 재집계 실행일 2026-08-04). 공개 저장소 수치는 아래 절차로 외부에서 재현할 수 있으며, 비공개 저장소 수치는 접근 권한이 있는 경우에 한해 동일 절차로 재현됩니다.</p><p class="lang-en">This section records the procedure and results of the recount <strong>actually performed</strong> while preparing this report (data snapshot 2026-08-03 · recount executed 2026-08-04). The public repository figures can be reproduced externally by the procedure below; the private repository figures reproduce under the same procedure only for those with access.</p>
+<table>
+  <thead><tr><th><span class="lang-ko">항목</span><span class="lang-en">Item</span></th><th><span class="lang-ko">내용</span><span class="lang-en">Detail</span></th></tr></thead>
+  <tbody>
+    <tr><td><span class="lang-ko">대상 범위</span><span class="lang-en">Scope</span></td><td><span class="lang-ko">3개 GitHub 네임스페이스 — <span class="mono">mossland</span>(User 계정), <span class="mono">MosslandOpenDevs</span>·<span class="mono">MosslandCore</span>(Organization). 포크 저장소 제외</span><span class="lang-en">Three GitHub namespaces — <span class="mono">mossland</span> (a User account) and <span class="mono">MosslandOpenDevs</span> · <span class="mono">MosslandCore</span> (Organizations). Forked repositories excluded</span></td></tr>
+    <tr><td><span class="lang-ko">엔드포인트</span><span class="lang-en">Endpoint</span></td><td><span class="mono">/users/{user}/repos</span> · <span class="mono">/orgs/{org}/repos</span> · <span class="mono">/repos/{owner}/{repo}/branches</span> · <span class="mono">/repos/{owner}/{repo}/commits</span> <span class="lang-ko">(모두 페이지네이션 전수)</span><span class="lang-en">(all fully paginated)</span></td></tr>
+    <tr><td><span class="lang-ko">집계 규칙</span><span class="lang-en">Counting rule</span></td><td><span class="lang-ko"><strong>기본 브랜치 · 저자일(author date) · 병합 커밋 포함 · SHA 기준 중복 제거</strong>, UTC 2026-04-01T00:00Z ~ 2026-07-01T00:00Z. API의 <span class="mono">since/until</span>은 커미터일 기준이므로 더 넓은 창으로 조회한 뒤 저자일로 필터링합니다.</span><span class="lang-en"><strong>Default branch · author date · merge commits included · deduplicated by SHA</strong>, UTC 2026-04-01T00:00Z to 2026-07-01T00:00Z. The API's <span class="mono">since/until</span> work on committer date, so a wider window is queried and then filtered by author date.</span></td></tr>
+    <tr><td><span class="lang-ko">공개 저장소 재집계</span><span class="lang-en">Public repository recount</span></td><td><span class="lang-ko"><strong>범위별로 나누어 산출했습니다.</strong><br>· <strong>MosslandOpenDevs만</strong>(Q1 범위 · 비포크 51개) — 기본 브랜치 247 · <strong>전 브랜치 261</strong><br>· <strong>3개 네임스페이스</strong>(현행 공시 범위 · 비포크 58개) — 기본 브랜치 <strong>259</strong> · 전 브랜치 273<br>Q1 목표와 비교 가능한 값은 <strong>261</strong>이며, 본 리포트의 공시 지표(<strong>259</strong>)는 3개 네임스페이스 기본 브랜치 기준입니다 <span class="vb v1">V1</span></span><span class="lang-en"><strong>Computed separately by scope.</strong><br>· <strong>MosslandOpenDevs only</strong> (the Q1 scope · 51 non-fork repositories) — default branch 247 · <strong>all branches 261</strong><br>· <strong>Three namespaces</strong> (the current disclosure scope · 58 non-fork repositories) — default branch <strong>259</strong> · all branches 273<br>The figure comparable with the Q1 target is <strong>261</strong>; the disclosure metric in this report (<strong>259</strong>) is the three-namespace default-branch figure <span class="vb v1">V1</span></span></td></tr>
+    <tr><td><span class="lang-ko">공개 커밋 목표 판정</span><span class="lang-en">Assessment of the public commit target</span></td><td><span class="lang-ko">Q1 목표(≥500)는 <strong>MosslandOpenDevs 공개 저장소 · 브랜치 무관</strong> 기준이므로, 동일 범위·동일 규칙의 <strong>261건</strong>을 판정 근거로 사용 — 목표 대비 약 48% 미달(§1.2). 범위를 넓힌 273건으로 보더라도 미달 판정은 동일합니다.</span><span class="lang-en">The Q1 target (≥ 500) was set on a <strong>MosslandOpenDevs public repositories, branch-agnostic</strong> basis, so the <strong>261</strong> from the same scope and same rule is used as the basis for assessment — about 48% short of the target (§1.2). The verdict is unchanged even on the wider figure of 273.</span></td></tr>
+    <tr><td><span class="lang-ko">디지털 트윈 트랙</span><span class="lang-en">Digital twin track</span></td><td><span class="lang-ko">비공개 2개 저장소의 기본 브랜치 합계 <strong>1,086건</strong>으로 공시치와 일치. 월별 4월 455 · 5월 324 · 6월 307(합계 1,086)도 일치. 두 저장소에는 저자일 2026-02-12~03-31 기준 <strong>512건</strong>의 트랙 개시 이전 이력이 있으나 저자일 규칙으로 전량 제외되며, 분기 구간에서 저자일↔커미터일 7일 초과 괴리는 0건입니다(§6.4) <span class="vb v3">V3</span></span><span class="lang-en">The default-branch total across the two private repositories is <strong>1,086</strong>, matching the disclosed figure. The monthly split also matches: April 455 · May 324 · June 307 (total 1,086). The two repositories hold <strong>512</strong> commits of history predating the start of the track (author dates 2026-02-12 to 03-31), all of which the author-date rule excludes, and within the quarter there are zero commits where author and committer dates differ by more than seven days (§6.4) <span class="vb v3">V3</span></span></td></tr>
+    <tr><td><span class="lang-ko">커밋 작성 주체</span><span class="lang-en">Commit authorship</span></td><td><span class="lang-ko">디지털 트윈 트랙 1,086건은 전량 <strong>재단 GitHub 조직 구성원 계정</strong>으로 작성. 성과물·지식재산 귀속은 이와 별개입니다(§6.3). 개인 식별 정보는 본 리포트에 기재하지 않습니다 <span class="vb v3">V3</span></span><span class="lang-en">All 1,086 commits on the digital twin track were authored from <strong>accounts that are members of the Foundation's GitHub organisations</strong>. Ownership of the output and of the intellectual property is a separate matter (§6.3). No personally identifying information is recorded in this report <span class="vb v3">V3</span></span></td></tr>
+    <tr><td><span class="lang-ko">블로그 19건</span><span class="lang-en">The 19 blog posts</span></td><td><span class="lang-ko">KO/EN 동일일 페어 7건(14편) + 단독 5편 = <strong>19편 · 12개 주제</strong>. 단독 5편은 04-30 · 05-12 · 05-14(2편) · 05-22. 목록은 §4.2 <span class="vb v1">V1</span></span><span class="lang-en">7 same-day KO/EN pairs (14 posts) + 5 standalone posts = <strong>19 posts across 12 topics</strong>. The 5 standalone posts are dated 04-30 · 05-12 · 05-14 (two) · 05-22. The list is in §4.2 <span class="vb v1">V1</span></span></td></tr>
+    <tr><td><span class="lang-ko">유통량</span><span class="lang-en">Circulating supply</span></td><td><span class="lang-ko">§A.2의 3층 구분(계획 상한 V1 / 보고·추정 V2 / 온체인 실현 미산출)을 적용. 계획 근거는 2025-01-09 공시 「MOC 유통계획」</span><span class="lang-en">The three-layer split of §A.2 applies (plan ceiling V1 / reported/estimated V2 / on-chain realised not computed). The basis for the plan is the 2025-01-09 disclosure "MOC Supply Plan"</span></td></tr>
+    <tr><td><span class="lang-ko">비공개 저장소 표기</span><span class="lang-en">Naming of private repositories</span></td><td><span class="lang-ko">저장소명·제품명은 2026-04-21 공시의 익명화 수위를 넘지 않도록 본 절에서도 기재하지 않습니다(§6.5)</span><span class="lang-en">Repository and product names are withheld in this section too, so as not to exceed the level of anonymisation in the 2026-04-21 disclosure (§6.5)</span></td></tr>
+  </tbody>
+</table>
+<p class="small lang-ko"><strong>공시 수치의 기준에 대하여</strong> — 본 리포트는 <strong>외부에서 재현 가능한 수치를 공시 기준으로 채택</strong>했습니다. 동일 절차로 비공개 저장소(33개)를 집계하면 <strong>1,686건이 정확히 재현</strong>되고, 공개 저장소는 <strong>259건</strong>이 재현됩니다. 초기 집계본은 공개 259건을 <strong>258건</strong>으로, 특정 저장소 1건을 적게 계상하고 있었으나(해당 저장소: 재집계 113 · 초기 집계 112), 어떤 규칙이 그 1건을 제외했는지 확인되지 않았고 <strong>V1은 &ldquo;공개 출처로 추적 가능&rdquo;을 요구하므로</strong>, 재현되지 않는 값을 유지하지 않고 <strong>259 · 총 1,945로 정정</strong>했습니다. 이에 따라 파생 수치(에이전트 시스템 155, 비-컨소시엄 859, 트랙 비중 55.8%, Figure 6.2·6.3)도 함께 재계산했습니다. 3분기에는 재단 집계 스크립트를 §A.3의 절차와 대조해 두 경로가 같은 값을 내도록 정합화합니다(§13.1 ④).</p><p class="small lang-en"><strong>On the basis of the disclosed figures</strong> — this report <strong>adopts externally reproducible figures as its disclosure basis</strong>. Applying the same procedure to the private repositories (33) reproduces <strong>1,686 exactly</strong>, and the public repositories reproduce as <strong>259</strong>. The initial count had public commits at <strong>258</strong> rather than 259, undercounting one repository by one commit (that repository: recount 113 · initial count 112); since no rule could be identified that would exclude that commit, and <strong>V1 requires "traceable to public sources"</strong>, the non-reproducible value was not retained and the figure was <strong>corrected to 259 · 1,945 in total</strong>. Derived figures were recomputed accordingly (agent systems 155, non-consortium 859, track share 55.8%, Figures 6.2 and 6.3). In Q3 the Foundation's counting script will be reconciled against the procedure in §A.3 so that both paths return the same value (§13.1 ④).</p>
+
+<h3>A.4 <span class="lang-ko">한계 및 후속 과제</span><span class="lang-en">Limitations</span></h3>
+<ul>
+  <li><span class="lang-ko"><strong>온체인 기준 실현 유통량 미산출</strong> — 본 리포트의 분기말 유통량은 유통계획(V1)과 일치하는 <strong>보고·추정값(V2)</strong>이며, 기준 블록·비유통 지갑 잔액·전환 트랜잭션으로 산출하는 <strong>온체인 실현 유통량은 산출하지 않았습니다</strong>(§A.2의 ③). 따라서 각 달에 실제로 전환이 집행된 시점은 본 리포트로 확정되지 않습니다. 산출 방법과 기준 블록을 정의해 3분기부터 공시하는 것을 후속 과제로 둡니다.</span><span class="lang-en"><strong>On-chain realised circulating supply not computed</strong> — the quarter-end circulating supply in this report is the <strong>reported/estimated figure (V2)</strong>, which agrees with the supply plan (V1); the <strong>on-chain realised circulating supply, computed from a reference block, non-circulating wallet balances and conversion transactions, was not computed</strong> (③ of §A.2). This report therefore does not establish when conversion was actually executed in any given month. Defining the method and the reference block, and disclosing the figure from Q3, is held as a follow-up task.</span></li>
+  <li><span class="lang-ko"><strong>대시보드-리포트 수치 불일치</strong> — disclosure.moss.land 개발 섹션은 일부 저장소만 추적해 본 리포트 총계와 다릅니다. 3분기 정합화 예정(§13.1). 정합화 전까지 본 리포트 §6.1 기준이 공시 기준입니다.</span><span class="lang-en"><strong>Dashboard and report figures do not agree</strong> — the development section of disclosure.moss.land tracks only some repositories and so differs from the totals in this report. Reconciliation is planned for Q3 (§13.1). Until then the §6.1 basis in this report is the disclosure basis.</span></li>
+  <li><span class="lang-ko"><strong>비공개 저장소 수치의 외부 검증 불가</strong> — V3 수치는 재단 집계이며, 집계 스크립트·기준은 내부 보존됩니다. 완화 장치는 결과 서비스(V2)와 공시 문서(V1)입니다.</span><span class="lang-en"><strong>Private repository figures cannot be verified externally</strong> — V3 figures are the Foundation's own count, and the counting scripts and criteria are retained internally. The mitigations are the resulting services (V2) and the disclosure documents (V1).</span></li>
+  <li><span class="lang-ko"><strong>일부 프로젝트 서술의 커밋 로그 기반 재구성</strong> — 팀 제출 요약이 없는 트랙(디지털 트윈·AI 미디어 일부)은 커밋 로그에서 재구성되었으며, 해당 서술은 공시 수위 내에서 트랙 단위로만 기술됩니다(§6.1 표기 원칙).</span><span class="lang-en"><strong>Some project narratives are reconstructed from commit logs</strong> — tracks with no team-submitted summary (the digital twin track and parts of AI media) were reconstructed from commit logs, and those narratives are described only at track level, within the permitted disclosure level (the notation principle in §6.1).</span></li>
+  <li><span class="lang-ko"><strong>AEC-Fundamentals 이슈 단위 지식 활동 미집계</strong> — 커밋 기준 집계의 사각지대로, 이슈 집계 편입을 검토합니다.</span><span class="lang-en"><strong>Issue-level knowledge activity in AEC-Fundamentals is not counted</strong> — a blind spot of commit-based counting; bringing issues into the count is under consideration.</span></li>
+</ul>
+
+<h2 class="section" id="appB"><span class="num">§B</span><span class="lang-ko">AI 보조 작성 고지</span><span class="lang-en">AI Authoring Notice</span></h2>
+<p class="lang-ko">본 리포트는 Human-in-the-Loop(HITL) 원칙 아래 작성됩니다 — (1) 자동 메타데이터 수집(GitHub API·공시 대시보드·RSS) → (2) LLM 초안 작성 → (3) <strong>담당 팀 사실 검증</strong>(초안의 검증 마커 전수 해소) → (4) 재단 검토·승인 → (5) 발행. 초안 단계의 모든 사실 서술 중 외부 검증이 불가한 항목에는 검증 마커가 부착되며, 마커가 남아 있는 버전은 발행되지 않습니다. 2026-02 공개된 AI 생성 콘텐츠 표시 정책 초안을 따르며, 확정판 발행(§13) 후 그 기준으로 갱신합니다.</p><p class="lang-en">This report is prepared under a Human-in-the-Loop (HITL) principle — (1) automated metadata collection (GitHub API, disclosure dashboard, RSS) → (2) LLM drafting → (3) <strong>fact verification by the responsible teams</strong> (every verification marker in the draft resolved) → (4) Foundation review and approval → (5) publication. At the draft stage every factual statement that cannot be verified externally carries a verification marker, and no version is published while markers remain. It follows the AI-generated content labelling policy draft published in 2026-02, and will be updated to the final version once that is published (§13).</p>
+
+<h2 class="section" id="appC"><span class="num">§C</span><span class="lang-ko">용어 해설</span><span class="lang-en">Glossary</span></h2>
+<table>
+  <thead><tr><th><span class="lang-ko">용어</span><span class="lang-en">Term</span></th><th><span class="lang-ko">설명</span><span class="lang-en">Description</span></th></tr></thead>
+  <tbody>
+    <tr><td>SIWE</td><td><span class="lang-ko">Sign-In with Ethereum — 지갑 개인키 서명으로 주소 통제권을 증명하는 표준. 트랜잭션이 아니므로 가스비가 들지 않음.</span><span class="lang-en">Sign-In with Ethereum — a standard for proving control of an address by signing with the wallet's private key. It is not a transaction, so there is no gas cost.</span></td></tr>
+    <tr><td>Activation Support / Exit Pass</td><td><span class="lang-ko">Passport의 전환 지원 체계 — 거래소→자가지갑 출금 수수료 보전 / 서명만으로 돌아가는 가스리스 복귀 경로.</span><span class="lang-en">Passport's transition support scheme — reimbursement of exchange-to-self-custody withdrawal fees, and a gasless return path that works by signature alone.</span></td></tr>
+    <tr><td><span class="lang-ko">유통량 전환</span><span class="lang-en">Circulating supply conversion</span></td><td><span class="lang-ko">재단 보유(비유통) 물량이 유통 가능 상태로 바뀌는 것. 지출(집행)과 구분됨 (§2.7).</span><span class="lang-en">Foundation-held (non-circulating) tokens becoming available to circulate. Distinct from spending (disbursement) (§2.7).</span></td></tr>
+    <tr><td>AX Sprint</td><td><span class="lang-ko">국토교통부 「AI응용제품 신속상용화 지원사업(국토·교통)」 — 본 리포트에서는 해당 사업 Type 2 트랙에서 2026-06-25 선정된 과제의 컨소시엄 협력을 지칭.</span><span class="lang-en">MOLIT's "Rapid Commercialisation Support Programme for AI-Applied Products (Land &amp; Transport)" — in this report it refers to consortium collaboration on the project selected on 2026-06-25 under the programme's Type 2 track.</span></td></tr>
+    <tr><td>IEEE 2888</td><td><span class="lang-ko">물리 세계와 가상 세계의 인터페이스(센서·액추에이터·디지털 트윈 동기화)를 다루는 국제표준 워킹그룹.</span><span class="lang-en">An international standards working group covering the interface between the physical and virtual worlds (sensors, actuators, digital twin synchronisation).</span></td></tr>
+    <tr><td>LOI</td><td><span class="lang-ko">Letter of Intent — 법적 구속력 없는 관심·참여 의향 표명.</span><span class="lang-en">Letter of Intent — a non-binding expression of interest or intent to participate.</span></td></tr>
+    <tr><td><span class="lang-ko">디지털 트윈</span><span class="lang-en">Digital twin</span></td><td><span class="lang-ko">실제 건물·공간의 구조와 운영 신호(센서·영상·재실)를 동기화한 가상 모델.</span><span class="lang-en">A virtual model synchronised with the structure and operational signals (sensors, video, occupancy) of a real building or space.</span></td></tr>
+    <tr><td><span class="lang-ko">인스턴싱 / 배칭</span><span class="lang-en">Instancing / batching</span></td><td><span class="lang-ko">반복 형상을 GPU에서 한 번에 그리는 렌더링 최적화 — 대형 건물 모델의 브라우저 구동 핵심 기법.</span><span class="lang-en">A rendering optimisation that draws repeated geometry in a single GPU pass — the key technique for running large building models in a browser.</span></td></tr>
+    <tr><td>MIP</td><td><span class="lang-ko">Mossland Improvement Proposal — Agora의 거버넌스 제안 단위.</span><span class="lang-en">Mossland Improvement Proposal — the unit of a governance proposal in Agora.</span></td></tr>
+    <tr><td>V1 · V2 · V3</td><td><span class="lang-ko">본 리포트의 검증 가능성 등급 (§6.6).</span><span class="lang-en">The verifiability tiers used in this report (§6.6).</span></td></tr>
+  </tbody>
+</table>
+
+<h2 class="section" id="safeharbor"><span class="num">§D</span><span class="lang-ko">미래예측 진술 고지</span><span class="lang-en">Forward-Looking Statements</span></h2>
+<p class="lang-ko">본 리포트의 §13(방향성·로드맵)을 포함한 미래 계획·목표·전망은 작성 시점의 내부 판단이며, 계약적 약속이 아닙니다. 규제·시장·기술·외부 협력 등 재단이 통제할 수 없는 요인에 따라 실제 결과는 서술과 다를 수 있습니다. 컨소시엄 관련 서술은 협약 체결·수행·사업화 결과를 보장하지 않으며, 재단 수익 또는 MOC 시장 가치에 대한 직접적 인과를 시사하지 않습니다. 본 리포트는 투자 권유가 아닙니다.</p><p class="lang-en">Forward-looking plans, targets and outlooks in this report, including §13 (direction and roadmap), are internal judgements as at the time of writing and are not contractual commitments. Actual results may differ from what is described, depending on regulatory, market, technical and external-collaboration factors beyond the Foundation's control. Statements relating to the consortium do not guarantee execution of an agreement, performance, or commercialisation outcomes, and do not imply any direct causal link to Foundation revenue or to the market value of MOC. This report is not investment advice.</p>
+<h4><span class="lang-ko">데이터 정확성</span><span class="lang-en">Accuracy of data</span></h4>
+<p class="small lang-ko">수치는 §A의 방법론과 스냅샷 시점 기준이며, 이후 원출처 데이터의 변동으로 달라질 수 있습니다. 오류 발견 시 공시 저장소 이슈로 제보해 주시면 검토 후 정정판(버전 표기)으로 반영합니다.</p><p class="small lang-en">Figures follow the methodology in §A and the snapshot date, and may change as the underlying source data changes. If you find an error, please report it as an issue in the disclosure repository; it will be reviewed and reflected in a corrected edition (with a version marking).</p>
+<h4><span class="lang-ko">번역 · 해석 우선순위</span><span class="lang-en">Translation · order of interpretive precedence</span></h4>
+<p class="small lang-ko">한국어판이 기준이며, 영어 병기는 참고용입니다. 해석에 차이가 있는 경우 한국어판이 우선합니다.</p><p class="small lang-en">The Korean edition governs; the English text is provided for reference. Where interpretations differ, the Korean edition prevails.</p>
+<h4><span class="lang-ko">통합 공개판 · 버전</span><span class="lang-en">Consolidated public edition · version</span></h4>
+<p class="small lang-ko">발행판은 mossland.github.io/Disclosure-and-Materials/disclosures/2026-q2/ 에 HTML로, 공시 대시보드 Materials에 목록 등재됩니다. 개정 시 버전(v1.x)과 변경 내역을 본 절 하단에 기록합니다.</p><p class="small lang-en">The published edition appears as HTML at mossland.github.io/Disclosure-and-Materials/disclosures/2026-q2/ and is listed under Materials on the disclosure dashboard. Any revision records the version (v1.x) and the change history at the foot of this section.</p>
+
+<footer>
+  <p class="mono" style="margin-top:16px;font-size:11px">
+    Mossland_2026_Q2_Report_v1.0.html · Data snapshot 2026-08-03 (GitHub API · disclosure.moss.land · Medium 발행 아카이브 전수 · CoinGecko)
+  </p>
+  <p class="small" style="margin-top:10px">
+    <span class="lang-ko">© 2026 Mossland Foundation. 본 리포트의 텍스트·수치·시각 자료는 Mossland Foundation 및 원출처 보유자에게 권리가 있습니다.</span><span class="lang-en">© 2026 Mossland Foundation. Rights in the text, figures and visual material of this report belong to the Mossland Foundation and to the holders of the original sources.</span>
+  </p>
+</footer>
+
+</div>
+
+<script>
+  /* Language toggle + mobile table card labels.  The labels must follow the active
+     language: they are written into data-label, so they are re-derived on every switch. */
+  (function(){
+    var body = document.body;
+    var btns = Array.prototype.slice.call(document.querySelectorAll('.lang-toggle button'));
+
+    function relabel(){
+      var en = body.classList.contains('only-en');
+      document.querySelectorAll('table').forEach(function(table){
+        var ths = table.querySelectorAll('thead th');
+        if(!ths.length) return;
+        var headers = Array.prototype.map.call(ths, function(th){
+          var pick = th.querySelector(en ? '.lang-en' : '.lang-ko');
+          return (pick ? pick.textContent : th.textContent).trim();
+        });
+        table.querySelectorAll('tbody tr').forEach(function(tr){
+          /* rows continuing under a rowspan are short by however many cells the
+             spanning column swallowed, so index from the end, not the start */
+          var off = Math.max(0, headers.length - tr.cells.length);
+          Array.prototype.forEach.call(tr.cells, function(cell, i){
+            var h = headers[i + off];
+            if(h) cell.setAttribute('data-label', h);
+          });
+        });
+      });
+    }
+
+    function set(lang){
+      body.classList.toggle('only-ko', lang === 'ko');
+      body.classList.toggle('only-en', lang === 'en');
+      /* the Korean edition governs, so anything other than EN-only stays ko */
+      document.documentElement.lang = (lang === 'en') ? 'en' : 'ko';
+      btns.forEach(function(b){ b.classList.toggle('active', b.dataset.lang === lang); });
+      relabel();
+    }
+
+    btns.forEach(function(b){ b.addEventListener('click', function(){ set(b.dataset.lang); }); });
+    relabel();
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
2026년 2분기 활동·공시 리포트를 `disclosures/2026-q2/index.html`로 발행하고 README Materials 목록에 등재합니다. 경로·형식은 `2026-q1`과 동일합니다.

발행 URL: https://mossland.github.io/Disclosure-and-Materials/disclosures/2026-q2/

## 내용

- 자기완결형 HTML — 외부 script/stylesheet/이미지 0, 도표는 인라인 SVG 7개
- 한국어 791개 요소 전부에 영문 형제 요소 병기, 표지에서 **KO / KO+EN / EN** 전환
- AX Sprint 6/25 선정과 7/10 협약은 **별도 공시 MOSS-DISC-2026-0804를 1차 고지 창구로 참조**하며, 본 리포트가 최초 고지가 되지 않습니다

## 발행 전 검토에서 정정한 사항

| | 내용 |
|---|---|
| 수치 | §8.1 네임스페이스별 커밋이 12 / 509 / 1,423 = **1,944**로 헤드라인 1,945와 어긋났습니다. §A.3 규칙(기본 브랜치·저자일·병합 포함·SHA 중복 제거)으로 GitHub API를 재측정해 **12 / 512 / 1,421 = 1,945**로 정정했고, 공개 259·비공개 1,686과도 정확히 일치합니다 |
| 인용 | 4/21 공시 제목은 「…공동연구·**국제표준화 협력기관** 참여」인데 '공시 제목' 열이 "**파트너**"로 바꿔 인용하고 있었습니다. 원문대로 복원하고 §7.1 역할 행에 8/4 공시 §2의 "**(주관기관 아님)**"을 명시했습니다 |
| 정합 | §7.1 소제목 "컨소시엄 R&D 개발 **참여**"가 §6.3의 "협약 이전 활동이므로 과제 수행이 아니다"와 충돌 → "컨소시엄 기술축 연계 워크스트림" |
| 정합 | ❌미달 항목의 구제책을 "§13.1의 3분기 과제"라고 했으나 §13.1은 이를 판정 대상 아님으로 분류 → 문구 일치 |
| 범위 | "26개 과제"를 **국토교통부 소관 공모** 한정으로 명시(AX Sprint는 11개 부처 사업) |
| 누락 | §2.7 예정 전환 목록에 유통계획상 **2026-12 +1,000,000**이 빠져 있어 추가 |
| 번역 | §8.3 영문에서 기여자 MOC 지급 프로그램 문장과 "2분기 지급 실적 없음" 단서가 통째로 누락 → 복원. EN 모드에 한국어로 남던 표 헤더·셀·배지 22종 병기 |
| 표기 | 제3자 명칭을 4/21 공시 원문 표기로 통일하고, 공시 제6항 4)의 "재단과 제3자 간 직접 거래·협약 관계를 의미하지 않습니다" 단서를 복원 |
| 렌더링 | rowspan 아래 행의 모바일 카드 라벨이 한 칸씩 밀림(§5 17행 중 14행), EN 모드에서 섹션 제목이 본문 크기로 무너짐, 간트 라벨이 막대 밖으로 이탈 |
| 기타 | Figure 6.2·6.3 막대 폭이 정정 전 값 기준, 각주 순서 1→4→2→3, §1에 1.1 부재, §A.1↔§A.3 오참조, 목차 항목이 단 경계에서 분리 |

## 검증

- KO 791개 요소 전부 EN 형제 보유 · 배치 오류 0 · EN 내 한글 0
- KO/EN 간 검증 배지·출처 링크 불일치 0
- id 중복 0 · 내부 앵커 미해결 0 · 태그 균형 이상 없음
- 외부 링크 55개 중 저장소 내부 6건 포함 39개 200, 나머지 16개는 전부 medium.com이며 완전한 브라우저 헤더로도 403(봇 차단)
- KO / KO+EN / EN 세 모드와 좁은 화면을 헤드리스 렌더링으로 확인

## 남은 확인 사항

- 1,086커밋 귀속에 대한 에테리온 확인은 아직 진행 중입니다. 본문(§6.3 · §A.3)은 "재단 GitHub 조직 구성원 계정으로 작성되었으며, 고용 법인·비용 부담·지식재산 귀속은 확정하지 않는다"로 중립 서술하고 있어 과장은 없습니다
- 발행일은 2026-08-04로 표기되어 있습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)